### PR TITLE
Fix dependencies for local conda install of psycopg2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - pip~=21.0
   - python>=3.8,<3.10
   - pre-commit
+  - libpq
   - pip:
     - -r requirements.txt


### PR DESCRIPTION
This is currently in conflict with PR #73 , which removes local installation entirely. That conflict should be resolved before anything else.



psycopg2 can be installed two ways: from prebuilt binaries (`pip install psycopg2-binary`) or from source (`pip install psycopg2`). According to [their docs](https://www.psycopg.org/docs/install.html) psycopg2-binary is fine for dev but installing from source is preferred for prod (I don't know why).

Either way is a one line fix, we just have to pick one. It probably isn't worth much time deliberating because our postgres db is for local dev only.

For dev install, change `psycopg2` to `psycopg2-binary` in `requirements.txt`. For prod install, add `libpq` to `environment.yml` (the dependency in the docker container is satisfied via the postgres image).

I propose doing the prod install because it is preferred by psycopg2 and not any harder to do. That is what is in this PR.