### PR TITLE
Use remote file URI instead of relative path for remote archived files

### DIFF
--- a/src/dbcp/etl.py
+++ b/src/dbcp/etl.py
@@ -104,12 +104,12 @@ def etl_ncsl_state_permitting() -> Dict[str, pd.DataFrame]:
 
 def etl_fips_tables() -> Dict[str, pd.DataFrame]:
     """Master state and county FIPS table ETL."""
-    census_path = Path("census/tl_2021_us_county.zip")
-    fips = dbcp.extract.fips_tables.extract_fips(census_path)
+    census_uri = "gs://dgm-archive/census/tl_2021_us_county.zip"
+    fips = dbcp.extract.fips_tables.extract_fips(census_uri)
 
-    tribal_lands_path = Path("census/tl_2021_us_aiannh.zip")
+    tribal_lands_uri = "gs://dgm-archive/census/tl_2021_us_aiannh.zip"
     fips["tribal_land"] = dbcp.extract.fips_tables.extract_census_tribal_land(
-        tribal_lands_path
+        tribal_lands_uri
     )
 
     out = dbcp.transform.fips_tables.transform(fips)
@@ -174,10 +174,8 @@ def etl_energy_communities_by_county() -> dict[str, pd.DataFrame]:
 
 def etl_ballot_ready() -> dict[str, pd.DataFrame]:
     """ETL Ballot Ready election data."""
-    source_path = Path(
-        "ballot_ready/2023_04_05_climate_partners_upcoming_races_with_counties.csv"
-    )
-    raw_df = dbcp.extract.ballot_ready.extract(source_path)
+    source_uri = "gs://dgm-archive/ballot_ready/2023_04_05_climate_partners_upcoming_races_with_counties.csv"
+    raw_df = dbcp.extract.ballot_ready.extract(source_uri)
     transformed = dbcp.transform.ballot_ready.transform(raw_df)
     return transformed
 

--- a/src/dbcp/extract/ballot_ready.py
+++ b/src/dbcp/extract/ballot_ready.py
@@ -1,21 +1,19 @@
 """Module for extracting Ballot Ready data."""
-from pathlib import Path
-
 import pandas as pd
 
 import dbcp
 
 
-def extract(path: Path) -> dict[str, pd.DataFrame]:
+def extract(uri: str) -> dict[str, pd.DataFrame]:
     """Extract raw Ballot Ready data.
 
     Args:
-        path: path of data in GCS relatives to the root.
+        uri: uri of data in GCS relatives to the root.
 
     Returns:
         dfs: dictionary of dataframe name to raw dataframe.
     """
     dfs = {}
-    path = dbcp.extract.helpers.cache_gcs_archive_file_locally(path)
+    path = dbcp.extract.helpers.cache_gcs_archive_file_locally(uri)
     dfs["raw_ballot_ready"] = pd.read_csv(path)
     return dfs

--- a/src/dbcp/extract/fips_tables.py
+++ b/src/dbcp/extract/fips_tables.py
@@ -10,27 +10,27 @@ import pandas as pd
 import dbcp
 
 
-def _extract_census_counties(census_path: Path) -> pd.DataFrame:
+def _extract_census_counties(census_uri: Path) -> pd.DataFrame:
     """Extract canonical county FIPS tables from census data.
 
     Args:
-        census_path: path to zipped shapefiles.
+        census_uri: path to zipped shapefiles.
     """
-    path = dbcp.extract.helpers.cache_gcs_archive_file_locally(census_path)
+    path = dbcp.extract.helpers.cache_gcs_archive_file_locally(census_uri)
     counties = gpd.read_file(path)
     return counties
 
 
-def extract_census_tribal_land(archive_path: Path) -> pd.DataFrame:
+def extract_census_tribal_land(archive_uri: Path) -> pd.DataFrame:
     """Extract Tribal land in the census.
 
     Args:
-        archive_path: path of file to extract from the dgm-archive GCS bucket.
+        archive_uri: path of file to extract from the dgm-archive GCS bucket.
 
     Returns:
         output dataframes of county-level info.
     """
-    path = dbcp.extract.helpers.cache_gcs_archive_file_locally(archive_path)
+    path = dbcp.extract.helpers.cache_gcs_archive_file_locally(archive_uri)
     counties = gpd.read_file(path)
     return counties
 
@@ -50,13 +50,13 @@ def _extract_state_fips() -> pd.DataFrame:
     return states
 
 
-def extract_fips(census_path: Path) -> Dict[str, pd.DataFrame]:
+def extract_fips(census_uri: str) -> Dict[str, pd.DataFrame]:
     """Extract canonical state and county FIPS tables from census data and the addfips library.
 
     Returns:
         Dict[str, pd.DataFrame]: output dictionary of dataframes
     """
     fips_data = {}
-    fips_data["counties"] = _extract_census_counties(census_path=census_path)
+    fips_data["counties"] = _extract_census_counties(census_uri=census_uri)
     fips_data["states"] = _extract_state_fips()
     return fips_data

--- a/src/dbcp/extract/helpers.py
+++ b/src/dbcp/extract/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for extracting data."""
 import logging
 import os
+import re
 from pathlib import Path
 
 import pydata_google_auth
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def cache_gcs_archive_file_locally(
-    filename: str,
+    uri: Path,
     local_cache_dir: str = "/app/data/data_cache",
     revision_num: str = None,
 ) -> Path:
@@ -18,7 +19,7 @@ def cache_gcs_archive_file_locally(
     Cache a file stored in the GCS archive locally to a local directory.
 
     Args:
-        filename: the full file path in the "dgm-archive" bucket.
+        uri: the full file GCS URI.
         local_cache_dir: the local directory to cache the data.
         revision_num: The revision number of the object to access. If None,
             the latest version of the object will be used. This is helpful
@@ -27,13 +28,14 @@ def cache_gcs_archive_file_locally(
     Returns:
         Path to the local cache of the file.
     """
+    bucket_url, object_name = re.match("gs://(.*?)/(.*)", str(uri)).groups()
+
     local_cache_dir = Path(local_cache_dir)
-    filepath = local_cache_dir / filename
+    filepath = local_cache_dir / object_name
     if not filepath.exists():
         logger.info(
-            f"{filename} not found in {local_cache_dir}. Downloading from GCS bucket."
+            f"{object_name} not found in {local_cache_dir}. Downloading from GCS bucket."
         )
-        bucket_url = "dgm-archive"
 
         GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
         SCOPES = [
@@ -48,9 +50,9 @@ def cache_gcs_archive_file_locally(
         )
 
         if revision_num:
-            blob = bucket.blob(str(filename), generation=revision_num)
+            blob = bucket.blob(str(object_name), generation=revision_num)
         else:
-            blob = bucket.blob(str(filename))
+            blob = bucket.blob(str(object_name))
 
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "wb+") as f:


### PR DESCRIPTION
I noticed archive paths for files stored in github were the absolute local path where the files stored on GCS were paths relative to `/app/data/data_cache/`. This felt awkward so I decided to use the full GCS URI instead for remote files.

There's for sure a more graceful way to handle this caching behavior (PUDL's layered cache or maybe fsspec) but I figured this was good enough for now.