### PR TITLE
Use copy CSV instead of insert for pandas to postgres

### DIFF
--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -236,7 +236,7 @@ fossil_infrastructure_projects = Table(
     Column("project_description", String),
     Column("facility_description", String),
     Column("permit_description", String),
-    Column("cost_millions", Integer),
+    Column("cost_millions", Float),
     Column("raw_number_of_jobs_promised", String),
     Column("date_modified", DateTime),
     Column("co2e_tonnes_per_year", Float),


### PR DESCRIPTION
This PR:
- Improve performance by chaniging the `method` argument of `to_sql` calls to use a function [from the pandas docs](https://pandas.pydata.org/docs/user_guide/io.html#io-sql-method) that uses COPY CSV instead of INSERT.
- Creates a helper function that enforces datatypes on dataframes based on the types specified in the metadata.
- Changes `data_mart.fossil_infrastructure_projects.cost_millions` column from an Int to Float because I was getting a "could not cast int to float" error when enforcing the types.

On my comp `make etl_local` went from 6m39s -> 2m58s.