### PR TITLE
Update october 2023 ballot ready data

### DIFF
--- a/src/dbcp/__init__.py
+++ b/src/dbcp/__init__.py
@@ -1,5 +1,6 @@
 """The Down Ballot Climate Project (DBCP) Project."""
 import dbcp.data_mart  # noqa: F401
+import dbcp.data_mart.br_election_data  # noqa: F401
 import dbcp.data_mart.counties  # noqa: F401
 import dbcp.data_mart.projects  # noqa: F401
 import dbcp.etl  # noqa: F401

--- a/src/dbcp/data_mart/br_election_data.py
+++ b/src/dbcp/data_mart/br_election_data.py
@@ -60,7 +60,7 @@ def _create_county_commission_elections_long(
     ]
 
     # Aggregate
-    mode = lambda x: x.value_counts().index[0]  # noqa: E731
+    mode = lambda x: x.value_counts(dropna=False).index[0]  # noqa: E731
 
     grp_fields = [
         "election_id",

--- a/src/dbcp/etl.py
+++ b/src/dbcp/etl.py
@@ -175,7 +175,7 @@ def etl_energy_communities_by_county() -> dict[str, pd.DataFrame]:
 
 def etl_ballot_ready() -> dict[str, pd.DataFrame]:
     """ETL Ballot Ready election data."""
-    source_uri = "gs://dgm-archive/ballot_ready/BallotReady_upcoming_races_with_counties_08_14_2023.csv"
+    source_uri = "gs://dgm-archive/ballot_ready/Climate Partners_Upcoming Races_All Tiers_20231013.csv"
     raw_df = dbcp.extract.ballot_ready.extract(source_uri)
     transformed = dbcp.transform.ballot_ready.transform(raw_df)
     return transformed

--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -444,8 +444,12 @@ br_election_data = Table(
     Column("number_of_seats", Integer, nullable=False),
     Column("normalized_position_id", Integer, nullable=False),
     Column("normalized_position_name", String, nullable=False),
-    Column("frequency", String, nullable=False),
-    Column("reference_year", Integer, nullable=False),
+    Column(
+        "frequency", String, nullable=True
+    ),  # Starting 2023-10-03 update there were a couple hundred nulls
+    Column(
+        "reference_year", String, nullable=True
+    ),  # Starting 2023-10-03 update there were a couple hundred nulls
     Column("partisan_type", String),
     Column("race_created_at", DateTime, nullable=False),
     Column("race_updated_at", DateTime, nullable=False),

--- a/src/dbcp/metadata/data_warehouse.py
+++ b/src/dbcp/metadata/data_warehouse.py
@@ -1213,7 +1213,9 @@ br_positions = Table(
     metadata,
     Column("position_id", Integer, nullable=False, primary_key=True),
     Column("position_name", String, nullable=False),
-    Column("reference_year", Integer, nullable=False),
+    Column(
+        "reference_year", Integer, nullable=True
+    ),  # Starting 2023-10-03 update there were a couple hundred nulls
     Column("sub_area_name", String),
     Column("sub_area_value", String),
     Column("sub_area_name_secondary", String),
@@ -1224,7 +1226,9 @@ br_positions = Table(
     Column("is_retention", Boolean, nullable=False),
     Column("normalized_position_id", Integer, nullable=False),
     Column("normalized_position_name", String, nullable=False),
-    Column("frequency", String, nullable=False),
+    Column(
+        "frequency", String, nullable=True
+    ),  # Starting 2023-10-03 update there were a couple hundred nulls
     Column("partisan_type", String),
     schema=schema,
 )

--- a/src/dbcp/transform/ballot_ready.py
+++ b/src/dbcp/transform/ballot_ready.py
@@ -42,8 +42,6 @@ def _normalize_entities(ballot_ready: pd.DataFrame) -> dict[str, pd.DataFrame]:
     trns_dfs["br_elections"] = br_elections
 
     # Positions
-    position_pk_fields = ["position_id"]
-
     position_fields = [
         "reference_year",
         "position_id",
@@ -67,10 +65,11 @@ def _normalize_entities(ballot_ready: pd.DataFrame) -> dict[str, pd.DataFrame]:
     # and the future/current one are reflected in the data.
 
     # check if position_id is unique
-    br_positions = ballot_ready.drop_duplicates(subset=position_pk_fields)
+    br_positions = ballot_ready.drop_duplicates(subset=position_fields)
     is_duplciate_position = br_positions.position_id.duplicated(keep=False)
     duplicate_positions = br_positions[is_duplciate_position].copy()
 
+    logger.info(f"Found {len(duplicate_positions)} duplicate positions.")
     assert (
         len(duplicate_positions) <= 52
     ), f"Found more duplicate positions than expected: {len(duplicate_positions)}"

--- a/src/dbcp/transform/ballot_ready.py
+++ b/src/dbcp/transform/ballot_ready.py
@@ -42,6 +42,8 @@ def _normalize_entities(ballot_ready: pd.DataFrame) -> dict[str, pd.DataFrame]:
     trns_dfs["br_elections"] = br_elections
 
     # Positions
+    position_pk_fields = ["position_id"]
+
     position_fields = [
         "reference_year",
         "position_id",
@@ -65,7 +67,7 @@ def _normalize_entities(ballot_ready: pd.DataFrame) -> dict[str, pd.DataFrame]:
     # and the future/current one are reflected in the data.
 
     # check if position_id is unique
-    br_positions = ballot_ready.drop_duplicates(subset=position_fields)
+    br_positions = ballot_ready.drop_duplicates(subset=position_pk_fields)
     is_duplciate_position = br_positions.position_id.duplicated(keep=False)
     duplicate_positions = br_positions[is_duplciate_position].copy()
 


### PR DESCRIPTION
This PR updates the ballot ready data to use the October 2023 data. There are a few things to note:

- Based on their data dictionary`frequency` and `reference_year` are supposed to be required but there are a 345 nulls in this update.
- There are about 25 weird edge cases positions (0.04%) that have multiple frequencies and reference years because ballot ready keep the old and new values if there is a redistricting or law change.
- There are about 3x as many races in this batch. I assume because it is an election year.
- There are some races that still use the Valdez-Cordova Census Area. I copied all of the races between the Copper River and Chugach census areas.