### PR TITLE
Add MISO projects prior to 2017 using old GS snapshot

### DIFF
--- a/src/dbcp/data_mart/projects.py
+++ b/src/dbcp/data_mart/projects.py
@@ -787,7 +787,7 @@ def validate_project_change_log(
     ]
 
     # We expect some change in total projects count because not all projects have withdrawn and operational dates
-    expected_n_projects_change = 0.05
+    expected_n_projects_change = 0.06
     result_n_projects_change = abs(
         len(iso_projects_change_log) - len(iso_projects_long_format)
     ) / len(iso_projects_change_log)
@@ -800,7 +800,7 @@ def validate_project_change_log(
         {
             "CAISO": 0.02,
             "ISONE": 0.01,
-            "MISO": 0.01,
+            "MISO": 0.09,  # A lot of operational projects prior to 2010 are missing operational dates
             "NYISO": 0.18,  # A lot of withdrawn projects from the early 2000s are missing withdrawn and operational dates
             "PJM": 0.04,
             "SPP": 0.31,  # A lot of withdrawn projects from the early 2000s are missing withdrawn and operational dates
@@ -855,7 +855,7 @@ def validate_iso_regions_change_log(
         {
             "CAISO": 0.02,
             "ISONE": 0.01,
-            "MISO": 0.01,
+            "MISO": 0.09,  # A lot of operational projects prior to 2010 are missing operational dates
             "NYISO": 0.20,  # A lot of withdrawn projects from the early 2000s are missing withdrawn and operational dates
             "PJM": 0.04,
             "SPP": 0.31,  # A lot of withdrawn projects from the early 2000s are missing withdrawn and operational dates

--- a/src/dbcp/extract/gridstatus_isoqueues.py
+++ b/src/dbcp/extract/gridstatus_isoqueues.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 ISO_QUEUE_VERSIONS: dict[str, str] = {
     "miso": "1712351594795115",
+    "miso-pre-2017": "1709776311574737",
     "caiso": "1712351595132954",
     "pjm": "1712351595509644",
     "ercot": "1712351595819850",
@@ -31,9 +32,9 @@ def extract(iso_queue_versions: dict[str, str] = ISO_QUEUE_VERSIONS):
     """Extract gridstatus ISO Queue data."""
     iso_queues: dict[str, pd.DataFrame] = {}
     for iso, revision_num in iso_queue_versions.items():
-        uri = (
-            f"gs://dgm-archive/gridstatus/interconnection_queues/parquet/{iso}.parquet"
-        )
+        # MISO is an exception to the rule because we need multiple snapshots of the data
+        filename = iso if iso != "miso-pre-2017" else "miso"
+        uri = f"gs://dgm-archive/gridstatus/interconnection_queues/parquet/{filename}.parquet"
         path = dbcp.extract.helpers.cache_gcs_archive_file_locally(
             uri=uri, revision_num=revision_num
         )

--- a/src/dbcp/transform/gridstatus.py
+++ b/src/dbcp/transform/gridstatus.py
@@ -591,8 +591,28 @@ def _create_project_status_classification_from_multiple_columns(
     return iso_df
 
 
-def _transform_miso(iso_df: pd.DataFrame) -> pd.DataFrame:
-    """Make miso specific transformations."""
+def _transform_miso(post_2017: pd.DataFrame, pre_2017: pd.DataFrame) -> pd.DataFrame:
+    """Make miso specific transformations.
+
+    In the second half of 2023, MISO removed all projects that entered the queue prior to 2017.
+    Luckily, our first snapshot of MISO data from GS includes projects that entered the queue
+    prior to 2017. This function grabs all unique projects from both snapshots and combines them.
+
+    Args:
+        post_2017: MISO data from 2017 to present. This contains the latest MISO data.
+        pre_2017: The oldest snapshot of GS we have. Happens to include prior to 2017.
+    """
+    # grab projects that are only in pre_2017
+    only_in_pre_2017 = pre_2017[~pre_2017["queue_id"].isin(post_2017["queue_id"])]
+
+    # ensure there are no active projects in only_in_pre_2017
+    assert (
+        only_in_pre_2017["queue_status"].ne("Active").all()
+    ), "There are active projects in the pre-2017 MISO data that are not in the current MISO data."
+
+    # concat only_in_pre_2017 with iso_df
+    iso_df = pd.concat([post_2017, only_in_pre_2017])
+
     # When a MISO project is marked as "Done" it means the study process is complete but it is not operational.
     # There is a separate column called "Post Generator Interconnection Agreement Status" the project's status
     # after the IA is executed.
@@ -900,7 +920,7 @@ def _normalize_project_locations(iso_df: pd.DataFrame) -> pd.DataFrame:
         geocoded_locations[["county_id_fips", "project_id"]].duplicated(keep=False)
     ]
     assert (
-        len(duplicate_locations) <= 96
+        len(duplicate_locations) <= 106
     ), f"Found more duplicate locations in Grid Status location table than expected:\n {duplicate_locations}"
     return geocoded_locations
 
@@ -1008,15 +1028,24 @@ def transform(raw_dfs: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
         "nyiso": _transform_nyiso,
         "isone": _transform_isone,
     }
-
     projects = []
-    for iso, df in raw_dfs.items():
+    for iso, trns_func in iso_cleaning_functions.items():
         logger.info(f"Cleaning {iso} data.")
-        # Apply rename
-        renamed_df = df.rename(columns=COLUMN_RENAME_DICT).copy()
+        renamed_df = pd.DataFrame()
+        # MISO is a special case because we need multiple snapshots of the raw data
+        if iso == "miso":
+            miso_pre_2017 = (
+                raw_dfs["miso-pre-2017"].rename(columns=COLUMN_RENAME_DICT).copy()
+            )
+            miso_post_2017 = raw_dfs["miso"].rename(columns=COLUMN_RENAME_DICT).copy()
+            renamed_df = trns_func(miso_post_2017, miso_pre_2017)
+        else:
+            # Apply rename
+            df = raw_dfs[iso]
+            renamed_df = df.rename(columns=COLUMN_RENAME_DICT).copy()
 
-        # Apply iso specific cleaning functions
-        renamed_df = iso_cleaning_functions[iso](renamed_df)
+            # Apply iso specific cleaning functions
+            renamed_df = trns_func(renamed_df)
 
         renamed_df["region"] = iso
         renamed_df["entity"] = iso.upper()

--- a/src/dbcp/validation/tests.py
+++ b/src/dbcp/validation/tests.py
@@ -240,7 +240,7 @@ def test_county_wide_coverage(engine: Engine):
     ), "counties_wide_format does not contain all counties"
     notnull = df.notnull()
     assert (
-        notnull.any(axis=1).sum() == 2387
+        notnull.any(axis=1).sum() == 2390
     ), f"counties_wide_format has unexpected county coverage: {notnull[notnull.any(axis=1)]}"
 
 


### PR DESCRIPTION
At some point in 2023 MISO removed all projects that entered the queue prior to 2017 so our newer archives of the data only have projects that entered after 2017. Lucikly our older archives include projects prior to 2017. This PR combines the newer archive with any projects in the old archive that don't exist in the new one.