### PR TITLE
Widen ISO queue change log

### DIFF
--- a/docs/data-mart/iso_counties_change_log.md
+++ b/docs/data-mart/iso_counties_change_log.md
@@ -2,6 +2,8 @@
 
 Each row in the table is a monthly snap shot of projects that enter, are withdrawn and become operational queues for each county in the continental US.
 
+`iso_counties_new_clean_capacity_mw_changelog` and `iso_counties_new_clean_n_projects_changelog` are wide versions of this table where each row is a county and each column is the end date of a quarter.
+
 ## Column Descriptions
 
 | Subject | Column                            | Description                                 | Source | Notes |

--- a/docs/data-mart/iso_regions_change_log.md
+++ b/docs/data-mart/iso_regions_change_log.md
@@ -2,6 +2,8 @@
 
 Each row in the table is a monthly snap shot of projects that enter, are withdrawn and become operational queues for each ISO region.
 
+`iso_regions_new_clean_capacity_mw_changelog` and `iso_regions_new_clean_n_projects_changelog` are wide versions of this table where each row is a region and each column is the end date of a quarter.
+
 ## Column Descriptions
 
 | Subject | Column                            | Description                                 | Source | Notes |

--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -529,6 +529,67 @@ iso_regions_change_log = Table(
     schema=schema,
 )
 
+iso_counties_new_clean_n_projects_changelog = Table(
+    "iso_counties_new_clean_n_projects_changelog",
+    metadata,
+    Column("county_id_fips", String),
+    Column("2022-03", Float),
+    Column("2022-06", Float),
+    Column("2022-09", Float),
+    Column("2022-12", Float),
+    Column("2023-03", Float),
+    Column("2023-06", Float),
+    Column("2023-09", Float),
+    Column("2023-12", Float),
+    Column("2024-03", Float),
+    schema=schema,
+)
+iso_counties_new_clean_capacity_mw_changelog = Table(
+    "iso_counties_new_clean_capacity_mw_changelog",
+    metadata,
+    Column("county_id_fips", String),
+    Column("2022-03", Float),
+    Column("2022-06", Float),
+    Column("2022-09", Float),
+    Column("2022-12", Float),
+    Column("2023-03", Float),
+    Column("2023-06", Float),
+    Column("2023-09", Float),
+    Column("2023-12", Float),
+    Column("2024-03", Float),
+    schema=schema,
+)
+iso_regions_new_clean_n_projects_changelog = Table(
+    "iso_regions_new_clean_n_projects_changelog",
+    metadata,
+    Column("iso_region", String),
+    Column("2022-03", Float),
+    Column("2022-06", Float),
+    Column("2022-09", Float),
+    Column("2022-12", Float),
+    Column("2023-03", Float),
+    Column("2023-06", Float),
+    Column("2023-09", Float),
+    Column("2023-12", Float),
+    Column("2024-03", Float),
+    schema=schema,
+)
+iso_regions_new_clean_capacity_mw_changelog = Table(
+    "iso_regions_new_clean_capacity_mw_changelog",
+    metadata,
+    Column("iso_region", String),
+    Column("2022-03", Float),
+    Column("2022-06", Float),
+    Column("2022-09", Float),
+    Column("2022-12", Float),
+    Column("2023-03", Float),
+    Column("2023-06", Float),
+    Column("2023-09", Float),
+    Column("2023-12", Float),
+    Column("2024-03", Float),
+    schema=schema,
+)
+
 br_election_data = Table(
     "br_election_data",
     metadata,


### PR DESCRIPTION
This PR creates four new data mart tables:
- `iso_counties_new_clean_capacity_mw_changelog`
- `iso_counties_new_clean_n_projects_changelog`
- `iso_regions_new_clean_capacity_mw_changelog`
- `iso_regions_new_clean_n_projects_changelog`

Each row in these tables is a geography, columns are the year a month a quarter ended and the values are the number of new clean projects or capacity mw for the given geography and quarter.