### PR TITLE
Update BallotReady with 2025-6 data

### DIFF
--- a/notebooks/data_updates/ballot_ready/ballot_ready_update.ipynb
+++ b/notebooks/data_updates/ballot_ready/ballot_ready_update.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from google.cloud import storage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save old Ballot Ready data locally\n",
+    "client = storage.Client()\n",
+    "bucket = client.bucket(\"dgm-archive\")\n",
+    "blobs = bucket.list_blobs(prefix=\"ballot_ready/Climate Partners_Upcoming Races_All Tiers_20240524.csv\", versions=True)\n",
+    "for i, blob in enumerate(blobs):\n",
+    "    if i>1:\n",
+    "        exit # There should only be one file that has this name.\n",
+    "    blob.download_to_filename(\"ballot_ready_2024_05_24.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save old Ballot Ready data locally\n",
+    "client = storage.Client()\n",
+    "bucket = client.bucket(\"dgm-archive\")\n",
+    "blobs = bucket.list_blobs(prefix=\"ballot_ready/Climate Partners_Upcoming Races_2025-2026_20240826.csv\", versions=True)\n",
+    "for i, blob in enumerate(blobs):\n",
+    "    if i>1:\n",
+    "        exit # There should only be one file that has this name.\n",
+    "    blob.download_to_filename(\"ballot_ready_2024_08_26.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_24492/3133798857.py:2: DtypeWarning: Columns (11) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  old_br = pd.read_csv(\"ballot_ready_2024_05_24.csv\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Import old Ballot Ready data\n",
+    "old_br = pd.read_csv(\"ballot_ready_2024_05_24.csv\")\n",
+    "# Import new Ballot Ready data\n",
+    "new_br = pd.read_csv(\"ballot_ready_2024_08_26.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Empty DataFrame\n",
+      "Columns: [id, election_id, election_name, election_day, race_id, geofence_id, is_primary, is_runoff, is_unexpired, position_id, mtfcc, geo_id, position_name, sub_area_name, sub_area_value, sub_area_name_secondary, sub_area_value_secondary, state, level, tier, is_judicial, is_retention, number_of_seats, normalized_position_id, normalized_position_name, position_description, frequency, reference_year, partisan_type, counties, race_created_at, race_updated_at]\n",
+      "Index: []\n",
+      "\n",
+      "[0 rows x 32 columns]\n",
+      "Empty DataFrame\n",
+      "Columns: [id, election_id, election_name, election_day, race_id, geofence_id, is_primary, is_runoff, is_unexpired, position_id, mtfcc, geo_id, position_name, sub_area_name, sub_area_value, sub_area_name_secondary, sub_area_value_secondary, state, level, tier, is_judicial, is_retention, number_of_seats, normalized_position_id, normalized_position_name, position_description, frequency, reference_year, partisan_type, counties, race_created_at, race_updated_at]\n",
+      "Index: []\n",
+      "\n",
+      "[0 rows x 32 columns]\n",
+      "Empty DataFrame\n",
+      "Columns: [id, election_id, election_name, election_day, race_id, geofence_id, is_primary, is_runoff, is_unexpired, position_id, mtfcc, geo_id, position_name, sub_area_name, sub_area_value, sub_area_name_secondary, sub_area_value_secondary, state, level, tier, is_judicial, is_retention, number_of_seats, normalized_position_id, normalized_position_name, position_description, frequency, reference_year, partisan_type, counties, race_created_at, race_updated_at]\n",
+      "Index: []\n",
+      "\n",
+      "[0 rows x 32 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Confirm the data doesn't overlap:\n",
+    "print(new_br[new_br.election_id.isin(old_br.election_id)]) # Elections?\n",
+    "print(new_br[new_br.race_id.isin(old_br.race_id)]) # Races?\n",
+    "print(new_br[new_br.election_day.isin(old_br.election_day)]) # Election timespans?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Final election date in old data: 2024-12-14\n",
+      "First election date in new  data: 2025-02-04\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Confirm by looking at dates covered.\n",
+    "print(f\"Final election date in old data: {old_br.election_day.max()}\")\n",
+    "print(f\"First election date in new  data: {new_br.election_day.min()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New columns in the new data: set()\n",
+      "Columns no longer in the new data: set()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# New columns in the data\n",
+    "print(f\"New columns in the new data: {set(new_br.columns).difference(old_br.columns)}\")\n",
+    "# Missing columns in the new data - None!\n",
+    "print(f\"Columns no longer in the new data: {set(old_br.columns).difference(new_br.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are some geographic fields in the data that we aren't currently using. The [Ballot Ready](https://support.ballotready.org/interpreting-mtfcc-and-geoid) documentation notes:\n",
+    "\n",
+    "\"Mtfcc and geo_id fields should be treated as pairs. Meaning that there could be more than one record in the census file with the same geo_id, but the mtfcc value identifies the type of census entity. BallotReady datasets should be joined to the census file on both the mtfcc and geo_id.\"\n",
+    "\n",
+    "\"mtfcc values that start with X will not have any corresponding entry in the census file. These mtfcc/geo_id pairs are for custom boundaries that BallotReady collected, that are not available via the census. Note that there's not one clear explanation about how to use the custom mtfcc values.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    G5420\n",
+       "1    G5420\n",
+       "2    X0102\n",
+       "3    X0102\n",
+       "4    G5420\n",
+       "Name: mtfcc, dtype: object"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_br.mtfcc.head(5) # A 5 digit MAF/TIGER feature class code. Those starting with X come from Ballot Ready's research."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2        770\n",
+       "4        992\n",
+       "5      64599\n",
+       "7     102909\n",
+       "8          2\n",
+       "9         12\n",
+       "10     75211\n",
+       "12      8605\n",
+       "13         4\n",
+       "15        14\n",
+       "16         6\n",
+       "Name: geo_id, dtype: int64"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# GEO IDs vary in length based on what information they contain.\n",
+    "# https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html\n",
+    "new_br.geo_id.str.len().value_counts().sort_index()\n",
+    "# 2: State FIPS\n",
+    "# 4: State FIPS + Congressional district\n",
+    "# 5: State FIPS + County FIPS\n",
+    "# 7: State FIPS + 5-digit place\n",
+    "# 8: Not a valid length described by the Census - e.g., 53059.C7 - need to be normalized\n",
+    "# 9: Not a valid length described by the Census - e.g., 4205-2-13 - need to be normalized\n",
+    "# 10: State FIPS + County FIPS + County sub-division\n",
+    "# 12: State FIPS + County FIPS + Tract + Block Group\n",
+    "# 13: Not a valid length described by the Census - e.g., 53063.8 R/S/B - need to be normalized\n",
+    "# 15: State FIPS + County FIPS + Tract + Block\n",
+    "# 16: State FIPS + County FIPS + Tract + Block + Suffix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Regarding the `geofence_id`, the documentation notes:\n",
+    "\"Depending on the scope of your export, there can be multiple geofences for the same mtfcc/geo_id pair that are distinguished by the valid_from and valid_to fields. That's how we track how the boundaries for a given political jurisdiction can change over time (due to redistricting, annexations, etc.).\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_br.set_index(['race_id', 'geofence_id']).index.is_unique"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We don't see `valid_to` and `valid_from` fields in our CSV, and each race is only associated with one `geofence_id` in the data sample. For now, we use these fields to validate our geocoding, but until we need more granular data they don't seem to necessarily serve our use case better than the existing geocoding workflow."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dbcp-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/data_updates/ballot_ready/ballot_ready_update.ipynb
+++ b/notebooks/data_updates/ballot_ready/ballot_ready_update.ipynb
@@ -33,9 +33,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/thinky/miniforge3/envs/dbcp-dev/lib/python3.10/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
+      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n",
+      "/home/thinky/miniforge3/envs/dbcp-dev/lib/python3.10/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
+      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n"
+     ]
+    }
+   ],
    "source": [
     "# Save old Ballot Ready data locally\n",
     "client = storage.Client()\n",
@@ -49,14 +60,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_24492/3133798857.py:2: DtypeWarning: Columns (11) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_69213/1466442055.py:2: DtypeWarning: Columns (11) have mixed types. Specify dtype option on import or set low_memory=False.\n",
       "  old_br = pd.read_csv(\"ballot_ready_2024_05_24.csv\")\n"
      ]
     }
@@ -256,6 +267,110 @@
    "metadata": {},
    "source": [
     "We don't see `valid_to` and `valid_from` fields in our CSV, and each race is only associated with one `geofence_id` in the data sample. For now, we use these fields to validate our geocoding, but until we need more granular data they don't seem to necessarily serve our use case better than the existing geocoding workflow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Transformed Data\n",
+    "\n",
+    "Let's compare the geo ID and the geocoded state and county FIPS columns to ensure geocoding works as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2025-02-04 00:00:00\n",
+      "2026-12-12 00:00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "transformed_br = pd.read_parquet('../../../data/output/data_mart/br_election_data.parquet')\n",
+    "print(transformed_br.election_day.min())\n",
+    "print(transformed_br.election_day.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'old_br' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mold_br\u001b[49m\u001b[38;5;241m.\u001b[39minfo()\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'old_br' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "old_br.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 226079 entries, 0 to 226078\n",
+      "Data columns (total 31 columns):\n",
+      " #   Column                    Non-Null Count   Dtype         \n",
+      "---  ------                    --------------   -----         \n",
+      " 0   race_id                   226079 non-null  Int64         \n",
+      " 1   is_primary                226079 non-null  boolean       \n",
+      " 2   is_runoff                 226079 non-null  boolean       \n",
+      " 3   is_unexpired              226079 non-null  boolean       \n",
+      " 4   number_of_seats           226079 non-null  Int64         \n",
+      " 5   race_created_at           226079 non-null  datetime64[ns]\n",
+      " 6   race_updated_at           226079 non-null  datetime64[ns]\n",
+      " 7   election_id               226079 non-null  Int64         \n",
+      " 8   position_id               226079 non-null  Int64         \n",
+      " 9   election_name             226079 non-null  string        \n",
+      " 10  election_day              226079 non-null  datetime64[ns]\n",
+      " 11  position_name             226079 non-null  string        \n",
+      " 12  reference_year            226076 non-null  string        \n",
+      " 13  sub_area_name             90098 non-null   string        \n",
+      " 14  sub_area_value            98579 non-null   string        \n",
+      " 15  sub_area_name_secondary   5170 non-null    string        \n",
+      " 16  sub_area_value_secondary  5669 non-null    string        \n",
+      " 17  level                     226079 non-null  string        \n",
+      " 18  tier                      226079 non-null  Int64         \n",
+      " 19  is_judicial               226079 non-null  boolean       \n",
+      " 20  is_retention              226079 non-null  boolean       \n",
+      " 21  normalized_position_id    226079 non-null  Int64         \n",
+      " 22  normalized_position_name  226079 non-null  string        \n",
+      " 23  frequency                 226076 non-null  string        \n",
+      " 24  partisan_type             225721 non-null  string        \n",
+      " 25  county_name               226079 non-null  string        \n",
+      " 26  state_name                226079 non-null  string        \n",
+      " 27  raw_county                226079 non-null  string        \n",
+      " 28  raw_state                 226079 non-null  string        \n",
+      " 29  state_id_fips             226079 non-null  string        \n",
+      " 30  county_id_fips            226079 non-null  string        \n",
+      "dtypes: Int64(6), boolean(5), datetime64[ns](3), string(17)\n",
+      "memory usage: 48.3 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "transformed_br.info()"
    ]
   }
  ],

--- a/notebooks/data_updates/ballot_ready/ballot_ready_update.ipynb
+++ b/notebooks/data_updates/ballot_ready/ballot_ready_update.ipynb
@@ -1,34 +1,13 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
     "from google.cloud import storage"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 74,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Save old Ballot Ready data locally\n",
-    "client = storage.Client()\n",
-    "bucket = client.bucket(\"dgm-archive\")\n",
-    "blobs = bucket.list_blobs(prefix=\"ballot_ready/Climate Partners_Upcoming Races_All Tiers_20240524.csv\", versions=True)\n",
-    "for i, blob in enumerate(blobs):\n",
-    "    if i>1:\n",
-    "        exit # There should only be one file that has this name.\n",
-    "    blob.download_to_filename(\"ballot_ready_2024_05_24.csv\")"
    ]
   },
   {
@@ -40,48 +19,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/thinky/miniforge3/envs/dbcp-dev/lib/python3.10/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n",
-      "/home/thinky/miniforge3/envs/dbcp-dev/lib/python3.10/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a \"quota exceeded\" or \"API not enabled\" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. \n",
-      "  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)\n"
+      "/tmp/ipykernel_33/2772101518.py:9: DtypeWarning: Columns (11) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  old_br = pd.read_csv(old_br_path)\n"
      ]
     }
    ],
    "source": [
     "# Save old Ballot Ready data locally\n",
-    "client = storage.Client()\n",
-    "bucket = client.bucket(\"dgm-archive\")\n",
-    "blobs = bucket.list_blobs(prefix=\"ballot_ready/Climate Partners_Upcoming Races_2025-2026_20240826.csv\", versions=True)\n",
-    "for i, blob in enumerate(blobs):\n",
-    "    if i>1:\n",
-    "        exit # There should only be one file that has this name.\n",
-    "    blob.download_to_filename(\"ballot_ready_2024_08_26.csv\")"
+    "\n",
+    "from dbcp.extract.helpers import cache_gcs_archive_file_locally\n",
+    "\n",
+    "old_br_path = cache_gcs_archive_file_locally(\"gs://dgm-archive/ballot_ready/Climate Partners_Upcoming Races_All Tiers_20240524.csv\")\n",
+    "new_br_path = cache_gcs_archive_file_locally(\"gs://dgm-archive/ballot_ready/Climate Partners_Upcoming Races_2025-2026_20240826.csv\")\n",
+    "\n",
+    "# Import old Ballot Ready data\n",
+    "old_br = pd.read_csv(old_br_path)\n",
+    "# Import new Ballot Ready data\n",
+    "new_br = pd.read_csv(new_br_path)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_69213/1466442055.py:2: DtypeWarning: Columns (11) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  old_br = pd.read_csv(\"ballot_ready_2024_05_24.csv\")\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Import old Ballot Ready data\n",
-    "old_br = pd.read_csv(\"ballot_ready_2024_05_24.csv\")\n",
-    "# Import new Ballot Ready data\n",
-    "new_br = pd.read_csv(\"ballot_ready_2024_08_26.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -91,18 +50,12 @@
       "Empty DataFrame\n",
       "Columns: [id, election_id, election_name, election_day, race_id, geofence_id, is_primary, is_runoff, is_unexpired, position_id, mtfcc, geo_id, position_name, sub_area_name, sub_area_value, sub_area_name_secondary, sub_area_value_secondary, state, level, tier, is_judicial, is_retention, number_of_seats, normalized_position_id, normalized_position_name, position_description, frequency, reference_year, partisan_type, counties, race_created_at, race_updated_at]\n",
       "Index: []\n",
-      "\n",
-      "[0 rows x 32 columns]\n",
       "Empty DataFrame\n",
       "Columns: [id, election_id, election_name, election_day, race_id, geofence_id, is_primary, is_runoff, is_unexpired, position_id, mtfcc, geo_id, position_name, sub_area_name, sub_area_value, sub_area_name_secondary, sub_area_value_secondary, state, level, tier, is_judicial, is_retention, number_of_seats, normalized_position_id, normalized_position_name, position_description, frequency, reference_year, partisan_type, counties, race_created_at, race_updated_at]\n",
       "Index: []\n",
-      "\n",
-      "[0 rows x 32 columns]\n",
       "Empty DataFrame\n",
       "Columns: [id, election_id, election_name, election_day, race_id, geofence_id, is_primary, is_runoff, is_unexpired, position_id, mtfcc, geo_id, position_name, sub_area_name, sub_area_value, sub_area_name_secondary, sub_area_value_secondary, state, level, tier, is_judicial, is_retention, number_of_seats, normalized_position_id, normalized_position_name, position_description, frequency, reference_year, partisan_type, counties, race_created_at, race_updated_at]\n",
-      "Index: []\n",
-      "\n",
-      "[0 rows x 32 columns]\n"
+      "Index: []\n"
      ]
     }
    ],
@@ -115,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -135,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -167,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +134,7 @@
        "Name: mtfcc, dtype: object"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -212,7 +165,7 @@
        "Name: geo_id, dtype: int64"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -244,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -253,7 +206,7 @@
        "True"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,15 +233,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-02-04 00:00:00\n",
-      "2026-12-12 00:00:00\n"
+      "2023-02-07 00:00:00\n",
+      "2024-12-14 00:00:00\n"
      ]
     }
    ],
@@ -300,18 +253,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'old_br' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mold_br\u001b[49m\u001b[38;5;241m.\u001b[39minfo()\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'old_br' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 247247 entries, 0 to 247246\n",
+      "Data columns (total 32 columns):\n",
+      " #   Column                    Non-Null Count   Dtype  \n",
+      "---  ------                    --------------   -----  \n",
+      " 0   id                        247247 non-null  int64  \n",
+      " 1   election_id               247247 non-null  int64  \n",
+      " 2   election_name             247247 non-null  object \n",
+      " 3   election_day              247247 non-null  object \n",
+      " 4   race_id                   247247 non-null  int64  \n",
+      " 5   geofence_id               246694 non-null  float64\n",
+      " 6   is_primary                247247 non-null  object \n",
+      " 7   is_runoff                 247247 non-null  object \n",
+      " 8   is_unexpired              247247 non-null  object \n",
+      " 9   position_id               247247 non-null  int64  \n",
+      " 10  mtfcc                     247235 non-null  object \n",
+      " 11  geo_id                    247221 non-null  object \n",
+      " 12  position_name             247247 non-null  object \n",
+      " 13  sub_area_name             103388 non-null  object \n",
+      " 14  sub_area_value            114475 non-null  object \n",
+      " 15  sub_area_name_secondary   6619 non-null    object \n",
+      " 16  sub_area_value_secondary  7226 non-null    object \n",
+      " 17  state                     247247 non-null  object \n",
+      " 18  level                     247247 non-null  object \n",
+      " 19  tier                      247247 non-null  int64  \n",
+      " 20  is_judicial               247247 non-null  object \n",
+      " 21  is_retention              247247 non-null  object \n",
+      " 22  number_of_seats           247247 non-null  int64  \n",
+      " 23  normalized_position_id    247247 non-null  int64  \n",
+      " 24  normalized_position_name  247247 non-null  object \n",
+      " 25  position_description      247203 non-null  object \n",
+      " 26  frequency                 246845 non-null  object \n",
+      " 27  reference_year            246845 non-null  float64\n",
+      " 28  partisan_type             247022 non-null  object \n",
+      " 29  counties                  247247 non-null  object \n",
+      " 30  race_created_at           247247 non-null  object \n",
+      " 31  race_updated_at           247247 non-null  object \n",
+      "dtypes: float64(2), int64(7), object(23)\n",
+      "memory usage: 60.4+ MB\n"
      ]
     }
    ],
@@ -321,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -329,43 +316,43 @@
      "output_type": "stream",
      "text": [
       "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 226079 entries, 0 to 226078\n",
+      "RangeIndex: 218874 entries, 0 to 218873\n",
       "Data columns (total 31 columns):\n",
       " #   Column                    Non-Null Count   Dtype         \n",
       "---  ------                    --------------   -----         \n",
-      " 0   race_id                   226079 non-null  Int64         \n",
-      " 1   is_primary                226079 non-null  boolean       \n",
-      " 2   is_runoff                 226079 non-null  boolean       \n",
-      " 3   is_unexpired              226079 non-null  boolean       \n",
-      " 4   number_of_seats           226079 non-null  Int64         \n",
-      " 5   race_created_at           226079 non-null  datetime64[ns]\n",
-      " 6   race_updated_at           226079 non-null  datetime64[ns]\n",
-      " 7   election_id               226079 non-null  Int64         \n",
-      " 8   position_id               226079 non-null  Int64         \n",
-      " 9   election_name             226079 non-null  string        \n",
-      " 10  election_day              226079 non-null  datetime64[ns]\n",
-      " 11  position_name             226079 non-null  string        \n",
-      " 12  reference_year            226076 non-null  string        \n",
-      " 13  sub_area_name             90098 non-null   string        \n",
-      " 14  sub_area_value            98579 non-null   string        \n",
-      " 15  sub_area_name_secondary   5170 non-null    string        \n",
-      " 16  sub_area_value_secondary  5669 non-null    string        \n",
-      " 17  level                     226079 non-null  string        \n",
-      " 18  tier                      226079 non-null  Int64         \n",
-      " 19  is_judicial               226079 non-null  boolean       \n",
-      " 20  is_retention              226079 non-null  boolean       \n",
-      " 21  normalized_position_id    226079 non-null  Int64         \n",
-      " 22  normalized_position_name  226079 non-null  string        \n",
-      " 23  frequency                 226076 non-null  string        \n",
-      " 24  partisan_type             225721 non-null  string        \n",
-      " 25  county_name               226079 non-null  string        \n",
-      " 26  state_name                226079 non-null  string        \n",
-      " 27  raw_county                226079 non-null  string        \n",
-      " 28  raw_state                 226079 non-null  string        \n",
-      " 29  state_id_fips             226079 non-null  string        \n",
-      " 30  county_id_fips            226079 non-null  string        \n",
+      " 0   race_id                   218874 non-null  Int64         \n",
+      " 1   is_primary                218874 non-null  boolean       \n",
+      " 2   is_runoff                 218874 non-null  boolean       \n",
+      " 3   is_unexpired              218874 non-null  boolean       \n",
+      " 4   number_of_seats           218874 non-null  Int64         \n",
+      " 5   race_created_at           218874 non-null  datetime64[ns]\n",
+      " 6   race_updated_at           218874 non-null  datetime64[ns]\n",
+      " 7   election_id               218874 non-null  Int64         \n",
+      " 8   position_id               218874 non-null  Int64         \n",
+      " 9   election_name             218874 non-null  string        \n",
+      " 10  election_day              218874 non-null  datetime64[ns]\n",
+      " 11  position_name             218874 non-null  string        \n",
+      " 12  reference_year            218638 non-null  string        \n",
+      " 13  sub_area_name             86507 non-null   string        \n",
+      " 14  sub_area_value            96018 non-null   string        \n",
+      " 15  sub_area_name_secondary   4684 non-null    string        \n",
+      " 16  sub_area_value_secondary  5167 non-null    string        \n",
+      " 17  level                     218874 non-null  string        \n",
+      " 18  tier                      218874 non-null  Int64         \n",
+      " 19  is_judicial               218874 non-null  boolean       \n",
+      " 20  is_retention              218874 non-null  boolean       \n",
+      " 21  normalized_position_id    218874 non-null  Int64         \n",
+      " 22  normalized_position_name  218874 non-null  string        \n",
+      " 23  frequency                 218638 non-null  string        \n",
+      " 24  partisan_type             218663 non-null  string        \n",
+      " 25  county_name               218874 non-null  string        \n",
+      " 26  state_name                218874 non-null  string        \n",
+      " 27  raw_county                218874 non-null  string        \n",
+      " 28  raw_state                 218874 non-null  string        \n",
+      " 29  state_id_fips             218874 non-null  string        \n",
+      " 30  county_id_fips            218874 non-null  string        \n",
       "dtypes: Int64(6), boolean(5), datetime64[ns](3), string(17)\n",
-      "memory usage: 48.3 MB\n"
+      "memory usage: 46.8 MB\n"
      ]
     }
    ],
@@ -376,7 +363,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dbcp-dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -390,9 +377,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/dbcp/etl.py
+++ b/src/dbcp/etl.py
@@ -149,7 +149,7 @@ def etl_energy_communities_by_county() -> dict[str, pd.DataFrame]:
 
 def etl_ballot_ready() -> dict[str, pd.DataFrame]:
     """ETL Ballot Ready election data."""
-    source_uri = "gs://dgm-archive/ballot_ready/Climate Partners_Upcoming Races_All Tiers_20240524.csv"
+    source_uri = "gs://dgm-archive/ballot_ready/Climate Partners_Upcoming Races_2025-2026_20240826.csv"
     raw_df = dbcp.extract.ballot_ready.extract(source_uri)
     transformed = dbcp.transform.ballot_ready.transform(raw_df)
     return transformed

--- a/src/dbcp/transform/ballot_ready.py
+++ b/src/dbcp/transform/ballot_ready.py
@@ -1,4 +1,5 @@
 """Module for cleaning Ballot Ready data."""
+
 import logging
 
 import pandas as pd
@@ -204,10 +205,11 @@ def _explode_counties(raw_ballot_ready: pd.DataFrame) -> pd.DataFrame:
     # These ones contain both state and county FIPS. Some have letters or non FIPs
     # characters, so we shouldn't expect a perfect match.
     state_match = ballot_ready.geo_id.str[0:2] == ballot_ready.state_id_fips
-    logger.info(
-        f"State FIPS codes:{sum(state_match)} of {len(state_match)} geocoded state FIPS IDs match the Ballot Ready data ({sum(state_match)/len(state_match):.0%})"
-    )
-    assert sum(state_match) / len(state_match) > 0.99
+    expected_state_match = 0.99
+    result_state_match_coverage = sum(state_match) / len(state_match)
+    assert (
+        sum(state_match) / len(state_match) > expected_state_match
+    ), f"State FIPS codes:{sum(state_match)} of {len(state_match)} geocoded state FIPS IDs match the Ballot Ready data ({result_state_match_coverage:.0%}). Expected atleast {expected_state_match:.0%}"
 
     # All GEO IDs contain the state FIPS code. But only these contain the County FIPS:
     # 5 digits: State FIPS + County FIPS

--- a/src/dbcp/transform/ballot_ready.py
+++ b/src/dbcp/transform/ballot_ready.py
@@ -198,6 +198,30 @@ def _explode_counties(raw_ballot_ready: pd.DataFrame) -> pd.DataFrame:
 
     ballot_ready = pd.concat(valdez_corrections_dfs + [ballot_ready])
 
+    # Validate the geocoding against the GEO IDs that contain a state and county FIPS ID
+    # GEO IDs vary in length based on what information they contain.
+    # https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html
+    # These ones contain both state and county FIPS. Some have letters or non FIPs
+    # characters, so we shouldn't expect a perfect match.
+    state_match = ballot_ready.geo_id.str[0:2] == ballot_ready.state_id_fips
+    logger.info(
+        f"State FIPS codes:{sum(state_match)} of {len(state_match)} geocoded state FIPS IDs match the Ballot Ready data ({sum(state_match)/len(state_match):.0%})"
+    )
+    assert sum(state_match) / len(state_match) > 0.99
+
+    # All GEO IDs contain the state FIPS code. But only these contain the County FIPS:
+    # 5 digits: State FIPS + County FIPS
+    # 10 digits: State FIPS + County FIPS + County sub-division
+    # 12 digits: State FIPS + County FIPS + Tract + Block Group
+    # 15 digits: State FIPS + County FIPS + Tract + Block
+    # 16 digits: State FIPS + County FIPS + Tract + Block + Suffix
+    geo_ids = ballot_ready.loc[ballot_ready.geo_id.str.len().isin([5, 10, 12, 15, 16])]
+    county_match = geo_ids.geo_id.str[0:5] == geo_ids.county_id_fips
+    logger.info(
+        f"County FIPS codes:{sum(county_match)} of {len(county_match)} geocoded state FIPS IDs match the Ballot Ready data ({sum(county_match)/len(county_match):.0%})"
+    )
+    assert sum(county_match) / len(county_match) > 0.85
+
     # Drop unused columns
     ballot_ready = ballot_ready.drop(columns=["position_description"])
     ballot_ready = ballot_ready.rename(

--- a/src/dbcp/transform/ballot_ready.py
+++ b/src/dbcp/transform/ballot_ready.py
@@ -215,7 +215,10 @@ def _explode_counties(raw_ballot_ready: pd.DataFrame) -> pd.DataFrame:
     # 12 digits: State FIPS + County FIPS + Tract + Block Group
     # 15 digits: State FIPS + County FIPS + Tract + Block
     # 16 digits: State FIPS + County FIPS + Tract + Block + Suffix
-    geo_ids = ballot_ready.loc[ballot_ready.geo_id.str.len().isin([5, 10, 12, 15, 16])]
+    geo_ids = ballot_ready.loc[
+        (ballot_ready.geo_id.str.len().isin([5, 10, 12, 15, 16]))
+        & (ballot_ready.county_id_fips.notnull())
+    ]
     county_match = geo_ids.geo_id.str[0:5] == geo_ids.county_id_fips
     logger.info(
         f"County FIPS codes:{sum(county_match)} of {len(county_match)} geocoded state FIPS IDs match the Ballot Ready data ({sum(county_match)/len(county_match):.0%})"


### PR DESCRIPTION
This PR:

-  Creates a new notebook to compare old data and updated data. I created a notebook and directory for ballot ready updates. This notebook confirms that there is no overlap between the old and new data, and explores some of the new geospatial ID fields that have been added in the last year.
-  Adds a validation method that compares the `geoid` field in Ballot Ready data against our own geocoding.
-  Updates the Ballot Ready ETL to grab the latest archived data.

Currently out of scope, but a possible extension:
- Replace `add_fips()` from PUDL with the Google geocoding method used elsewhere. Could also get taken up as part of #378.