### PR TITLE
Resolve BigQuery datetime issue

### DIFF
--- a/src/dbcp/cli.py
+++ b/src/dbcp/cli.py
@@ -1,4 +1,5 @@
 """A Command line interface for the down ballot project."""
+
 import argparse
 import logging
 import sys
@@ -66,9 +67,9 @@ def main():
         SPATIAL_CACHE.clear()
 
     if args.etl:
-        dbcp.etl.etl(args)
+        dbcp.etl.etl()
     if args.data_mart:
-        dbcp.data_mart.create_data_marts(args)
+        dbcp.data_mart.create_data_marts()
 
 
 if __name__ == "__main__":

--- a/src/dbcp/data_mart/__init__.py
+++ b/src/dbcp/data_mart/__init__.py
@@ -5,6 +5,8 @@ import logging
 import pkgutil
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 import dbcp
 from dbcp.constants import OUTPUT_DIR
@@ -15,7 +17,7 @@ from dbcp.validation.tests import validate_data_mart
 logger = logging.getLogger(__name__)
 
 
-def create_data_marts(args):  # noqa: max-complexity=11
+def create_data_marts():  # noqa: max-complexity=11
     """Collect and load all data mart tables to data warehouse."""
     engine = dbcp.helpers.get_sql_engine()
     data_marts = {}
@@ -64,8 +66,8 @@ def create_data_marts(args):  # noqa: max-complexity=11
     with engine.connect() as con:
         for table in metadata.sorted_tables:
             logger.info(f"Load {table.name} to postgres.")
-            df = enforce_dtypes(data_marts[table.name], table.name, "data_mart")
-            df = dbcp.helpers.trim_columns_length(df)
+            df = dbcp.helpers.trim_columns_length(data_marts[table.name])
+            df = enforce_dtypes(df, table.name, "data_mart")
             df.to_sql(
                 name=table.name,
                 con=con,
@@ -74,7 +76,10 @@ def create_data_marts(args):  # noqa: max-complexity=11
                 schema="data_mart",
                 method=psql_insert_copy,
             )
-
-            df.to_parquet(parquet_dir / f"{table.name}.parquet", index=False)
+            schema = dbcp.helpers.get_pyarrow_schema_from_metadata(
+                table.name, "data_mart"
+            )
+            pa_table = pa.Table.from_pandas(df, schema=schema)
+            pq.write_table(pa_table, parquet_dir / f"{table.name}.parquet")
 
     validate_data_mart(engine=engine)


### PR DESCRIPTION
Datetime columns were being loaded to BigQuery as integers. I think this is because the pandas `datetime[ns]` columns were being saved to the parquet files as a parquet nanosecond `Timestamp` type. BQ does not [list a conversion](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet#type_conversions) type for pyarrow nanosecond Timestamps. I guess it just converts it to an integer because that's how parquet stores timestamps.

I resolved this issue by creating pyarrow schemas from the sqlalchemy types and converting all datetime columns to use milliseconds instead of nanoseconds. It might be worth going through all these columns to figure out which ones actually need a time component.

