### PR TITLE
Rework CD github action

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -3,33 +3,21 @@ name: update-data
 
 on:
   push:
-    tags:
-      - "v20*"
     branches:
       - "dev"
+      - "main"
   workflow_dispatch:
   # Temporarily disable scheduled on runs because geocoding without a cache everytime is expensive
   # schedule:
   #   - cron: 5 7 * * 1-5
 
 jobs:
-  build:
+  archive:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-
-    env:
-      API_KEY_GOOGLE_MAPS: ${{ secrets.API_KEY_GOOGLE_MAPS }}
-      GITHUB_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule
-
     steps:
-      - name: Use dev branch if running on a schedule
-        if: ${{ (github.event_name == 'schedule') }}
-        run: |
-          echo "This action was triggered by a schedule." && echo "GITHUB_REF=dev" >> $GITHUB_ENV
-
-      - name: Checkout Repository
+      - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.GITHUB_REF }}
 
       - name: Who owns the workspace?
         run: ls -ld $GITHUB_WORKSPACE
@@ -63,12 +51,77 @@ jobs:
         run: |
           make archive_all
 
+  matrix_prep:
+    needs: archive # Ensure archive job finishes first
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set branch dynamically
+        id: set-matrix
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "matrix={\"include\":[{\"branch\":\"${{ github.ref_name }}\"}]}" >> $GITHUB_OUTPUT
+          else
+            echo "matrix={\"include\":[{\"branch\":\"main\"},{\"branch\":\"dev\"}]}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: echo matrix
+        run: echo ${{ steps.set-matrix.outputs.matrix }}
+
+  etl:
+    needs: matrix_prep # Ensure archive job finishes first
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # TODO: This should only run if the matrix_prep job is successful
+    strategy:
+      matrix: ${{ fromJSON(needs.matrix_prep.outputs.matrix) }}
+    env:
+      API_KEY_GOOGLE_MAPS: ${{ secrets.API_KEY_GOOGLE_MAPS }}
+      GITHUB_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule
+    steps:
+      - name: print matrix
+        run: echo ${{ matrix.branch }}
+
+      - name: Checkout Repository
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Who owns the workspace?
+        run: ls -ld $GITHUB_WORKSPACE
+
+      - uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.DGM_GITHUB_ACTION_CREDENTIALS }}"
+
+      - name: Display env variables
+        run: |
+          echo "Workspace directory: $GITHUB_WORKSPACE" \
+          echo "Google credentials path: $GOOGLE_GHA_CREDS_PATH" \
+
+      # Give the dbcp user ownership of the workspace
+      # So it can read and write files to the workspace
+      - name: Give the dbcp user ownership of the workspace
+        run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
+
+      - name: Set up Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
+      - name: Build and run Docker Compose services
+        run: |
+          docker-compose up -d
+
       - name: Run full ETL
         if: ${{ success() }}
         run: |
           make all
 
       - name: Run all test
+        if: ${{ success() }}
         run: |
           make test
 
@@ -100,12 +153,11 @@ jobs:
 
       # publish the outputs, grab the git sha of the commit step
       - name: Publish publish outputs
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.ref_name == 'dev')
         run: |
           docker compose run --rm app python dbcp/cli.py publish-outputs \
             -bq \
-            --build-ref ${{ github.ref_name }} \
-            --code-git-sha ${{ github.sha }} \
+            --build-ref ${{ matrix.branch }} \
+            --code-git-sha ${{ steps.checkout.outputs.commit }} \
             --settings-file-git-sha ${{ steps.commit_settings_file.outputs.commit_long_sha }} \
             --github-action-run-id ${{ github.run_id}}
 

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        # This will checkout the main branch on "schedule" and the specified branch on "workflow_dispatch"
+        # The archiver should probably be pulled out into its own repo so archive code and data don't diverge
 
       - name: Who owns the workspace?
         run: ls -ld $GITHUB_WORKSPACE
@@ -51,9 +53,22 @@ jobs:
         run: |
           make archive_all
 
+      # The google-github-actions/auth step is run as runner:docker,
+      # so we need to give the workspace back to runner:docker
+      - name: Give ownership of the workspace back to root
+        if: always()
+        run: sudo chown -R runner:docker $GITHUB_WORKSPACE
+
+      - name: Who owns the workspace?
+        if: always()
+        run: ls -ld $GITHUB_WORKSPACE
+
   matrix_prep:
     needs: archive # Ensure archive job finishes first
-    if: ${{ always() }}
+    # Only run if the archive job is successful or is skipped
+    # I had to add always() because the matrix_pre job wouldn't run if the archive job was skipped
+    # I think this happens because archive is skipped on push, but matrix_prep is not
+    if: ${{ always() && (needs.archive.result == 'success' || needs.archive.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -73,7 +88,7 @@ jobs:
   etl:
     needs: matrix_prep # Ensure archive job finishes first
     runs-on: ubuntu-latest
-    if: ${{ always() }} # TODO: This should only run if the matrix_prep job is successful
+    if: ${{ always() && needs.matrix_prep.result == 'success' }}
     strategy:
       matrix: ${{ fromJSON(needs.matrix_prep.outputs.matrix) }}
     env:

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -91,6 +91,7 @@ jobs:
     if: ${{ always() && needs.matrix_prep.result == 'success' }}
     strategy:
       matrix: ${{ fromJSON(needs.matrix_prep.outputs.matrix) }}
+      fail-fast: false
     env:
       API_KEY_GOOGLE_MAPS: ${{ secrets.API_KEY_GOOGLE_MAPS }}
       GITHUB_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule

--- a/src/dbcp/commands/publish.py
+++ b/src/dbcp/commands/publish.py
@@ -75,7 +75,7 @@ def load_parquet_files_to_bigquery(
 
     # Get the BigQuery dataset
     # the "production" bigquery datasets do not have a suffix
-    destination_suffix = "" if build_ref.startswith("v20") else f"_{build_ref}"
+    destination_suffix = "" if build_ref == "main" else f"_{build_ref}"
     dataset_id = f"{destination_blob_prefix}{destination_suffix}"
     dataset_ref = client.dataset(dataset_id)
 
@@ -136,12 +136,12 @@ class OutputMetadata(BaseModel):
 
     @validator("git_ref")
     def git_ref_must_be_dev_or_tag(cls, git_ref: str | None) -> str | None:
-        """Validate that the git ref is either "dev" or a tag starting with "v20"."""
+        """Validate that the git ref is either "dev" or "main"."""
         if git_ref:
-            if (git_ref in ("dev", "sandbox")) or git_ref.startswith("v20"):
+            if git_ref in ("dev", "sandbox", "main"):
                 return git_ref
             raise ValueError(
-                f'{git_ref} is not a valid Git rev. Must be "dev" or start with "v20"'
+                f'{git_ref} is not a valid Git rev. Must be "dev" or "main".'
             )
         return git_ref
 


### PR DESCRIPTION
This PR reworks the `update-data` github action so that both dev and prod can be updated daily. This action grabs the latest unpinned data then runs it through the ETL on `dev` and `main`.

We also won't push tags anymore we can't commit new settings files to a tag. I think it will be easiest to just have `main` associated with the prod data and `dev` with the development data.

With this change we won't be releasing a software version anymore which I think is fine because this repo isn't really a python package that other projects depend on. We'll still have robust data versioning. The BigQuery datasets are pulled from versioned folders in `gs://dgm-outputs`. These folders also contain a file that lists the git commit associated with the dataset. This way we can always figure out what code generated the data in prod and dev.