### PR TITLE
Update `update-data` workflow to run weekly

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -7,9 +7,8 @@ on:
       - "dev"
       - "main"
   workflow_dispatch:
-  # Temporarily disable scheduled on runs because geocoding without a cache everytime is expensive
-  # schedule:
-  #   - cron: 5 7 * * 1-5
+  schedule:
+    - cron: 0 0 * * 0
 
 jobs:
   archive:


### PR DESCRIPTION
I updated the `update-data` workflow to run weekly at midnight on Sunday. Do we want to change what day/time it's run?