### PR TITLE
Turn off Geocodio API version automatic loading

### DIFF
--- a/src/dbcp/transform/geocodio.py
+++ b/src/dbcp/transform/geocodio.py
@@ -161,7 +161,11 @@ def _geocode_locality(
         dataframe with geocoded locality information
     """
     GEOCODIO_API_KEY = os.environ["GEOCODIO_API_KEY"]
-    client = GeocodioClient(GEOCODIO_API_KEY)
+    # turn off automatic loading of latest Geocodio API version
+    # to ensure backwards compatibility
+    client = GeocodioClient(
+        GEOCODIO_API_KEY, version="1.9", auto_load_api_version=False
+    )
 
     geocoded_results = []
 


### PR DESCRIPTION
I got an email from Geocodio saying the following:

> The pygeocodio library has an auto_load_api_version option that is turned on by default. This feature automatically checks for and uses the newest Geocodio API version.
> While this is well-intentioned and makes sure you're always getting new features, it uses the newest version potentially without your knowledge—meaning your integration could suddenly start using backwards-incompatible changes and have issues as a result.
> We know how important stability is, so we want to make sure you're aware of this and can take control of your API version.

The email also suggests making the following change, which I've done in this PR:
```
# Geocodio Standard
client = GeocodioClient(YOUR_API_KEY, version="1.9", auto_load_api_version=False)
```

If we wanted to enforce an API version, then this PR makes the necessary change to do so. However, I don't think anything actually broke from the latest API version update, and it seems annoying to have to keep updating the API version here every time there's a new release.

**Questions**:
* What's the best way to be notified when a new API version is released? 
* Is there a way to automatically update this version number? Like how `dependabot` would update dependency versions. Can we include the Geocodio API package as a dependency in one of the files that dependabot tracks as a quick solution?
* Should we instead just have automatic version loading on, and revert to an older version if things break?
* If things break, will it be inobvious that this API version might be causing the breakage, which speaks to the cause for turning off the automatic API version loading