### PR TITLE
fix: pin geocodio API version as per recommendation

### DIFF
--- a/src/dbcp/transform/geocodio.py
+++ b/src/dbcp/transform/geocodio.py
@@ -161,7 +161,9 @@ def _geocode_locality(
         dataframe with geocoded locality information
     """
     GEOCODIO_API_KEY = os.environ["GEOCODIO_API_KEY"]
-    client = GeocodioClient(GEOCODIO_API_KEY)
+    client = GeocodioClient(
+        GEOCODIO_API_KEY, version="1.9", auto_load_api_version=False
+    )
 
     geocoded_results = []
 


### PR DESCRIPTION
We got an email from geocodio about how `pygeocodio` automatically uses the newest version of the `geocodio` API by default, and a recommendation to pin to a specific API version in case of breaking changes:

> ## What we recommend
>
> We recommend setting a specific API version when you initialize the library and turning off the auto-loading feature.
> 
> Here's how:
> 
> ### Geocodio Standard
> client = GeocodioClient(YOUR_API_KEY, version="1.9", auto_load_api_version=False)
> 
> ### Geocodio Enterprise  
> client = GeocodioClient(YOUR_API_KEY, custom_base_domain="https://api.enterprise.geocod.io", version="1.9", auto_load_api_version=False)
> 
> This way, you stay in control of when and how you upgrade. You can review our [API changelog](https://www.geocod.io/docs/#changelog) and upgrade on your own timeline when it makes sense for your integration.


So I have done so. The newest version is 1.9, though the last time we ran the ETL was before 1.9 came out (June 17th). The 1.9 changes are to the state legislative districts which I don't think we use, so I think we're good to pin to 1.9 for now!