### PR TITLE
change data update flow to use tag releases to prod

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -4,8 +4,9 @@ name: update-data
 on:
   push:
     branches:
-      - "dev"
       - "main"
+    tags:
+      - "v*"              # used for production releases
   workflow_dispatch:
   schedule:
     - cron: 0 0 * * 0
@@ -72,17 +73,58 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Set branch dynamically
+      - name: Check if this is a scheduled run
+        id: is_schedule
+        run: echo "::set-output name=scheduled::${{ github.event_name == 'schedule' }}"
+
+      - name: Fetch latest prod tag (only on schedule)
+        id: latest_tag
+        if: steps.is_schedule.outputs.scheduled == 'true'
+        run: |
+          # Install gh CLI
+          sudo apt-get update && sudo apt-get install -y gh
+
+          # Authenticate gh with token (use a PAT or GITHUB_TOKEN)
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+          # Get latest tag matching pattern (e.g. v*.*.*)
+          LATEST_TAG=$(gh release list --limit 1 --exclude-drafts --exclude-prereleases --pattern 'v*.*.*' --json tagName --jq '.[0].tagName')
+
+          echo "Latest tag: $LATEST_TAG"
+          echo "::set-output name=tag::$LATEST_TAG"
+
+      - name: Set matrix
         id: set-matrix
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "matrix={\"include\":[{\"branch\":\"${{ github.ref_name }}\"}]}" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # Get the branch or tag that triggered the push event
+            BRANCH_OR_TAG="${{ github.ref_name }}"
+
+            # If it looks like a version tag starting with 'v', mark as prod
+            if [[ "$BRANCH_OR_TAG" == v* ]]; then
+              TARGET="prod"
+            else
+              # Otherwise treat as dev (branch like main)
+              TARGET="dev"
+            fi
+
+            # Set the matrix with target and the actual git ref
+            echo "matrix={\"include\":[{\"target\":\"$TARGET\",\"ref\":\"$BRANCH_OR_TAG\"}]}" >> $GITHUB_OUTPUT
+
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # On schedule, get the latest prod tag from previous step output
+            LATEST_TAG="${{ steps.latest_tag.outputs.tag }}"
+
+            # Run matrix with dev (main branch) and prod (latest tag)
+            echo "matrix={\"include\":[{\"target\":\"dev\",\"ref\":\"main\"},{\"target\":\"prod\",\"ref\":\"$LATEST_TAG\"}]}" >> $GITHUB_OUTPUT
+
           else
-            echo "matrix={\"include\":[{\"branch\":\"main\"},{\"branch\":\"dev\"}]}" >> $GITHUB_OUTPUT
+            # For manual or other events, default to dev (main branch)
+            echo "matrix={\"include\":[{\"target\":\"dev\",\"ref\":\"main\"}]}" >> $GITHUB_OUTPUT
           fi
 
-      - name: echo matrix
-        run: echo ${{ steps.set-matrix.outputs.matrix }}
+      - name: Echo matrix
+        run: echo "${{ steps.set-matrix.outputs.matrix }}"
 
   etl:
     needs: matrix_prep # Ensure archive job finishes first
@@ -96,14 +138,17 @@ jobs:
       API_KEY_GOOGLE_MAPS: ${{ secrets.API_KEY_GOOGLE_MAPS }}
       GITHUB_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule
     steps:
-      - name: print matrix
-        run: echo ${{ matrix.branch }}
+      - name: Print matrix info
+        run: |
+          echo "Target: ${{ matrix.target }}"
+          echo "Ref: ${{ matrix.ref }}"
 
       - name: Checkout Repository
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          # Checkout the ref (branch or tag) from matrix
+          ref: ${{ matrix.ref }}
 
       - name: Who owns the workspace?
         run: ls -ld $GITHUB_WORKSPACE
@@ -167,23 +212,31 @@ jobs:
       - name: Give the dbcp user ownership of the workspace
         run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
 
-      # publish the outputs, grab the git sha of the commit step
+      # Publish the outputs, grab the git SHA of the commit step
       - name: Publish publish outputs
         run: |
           # Use the commit_settings_file hash if settings.yaml was updated
-          # If it wasn't updated that means there were no changes so use the
+          # If it wasn't updated, that means there were no changes, so use the
           # commit hash from the checkout step
           SETTINGS_FILE_SHA="${{ steps.commit_settings_file.outputs.commit_long_sha }}"
           if [ -z "$SETTINGS_FILE_SHA" ]; then
             SETTINGS_FILE_SHA="${{ steps.checkout.outputs.commit }}"
           fi
 
+          # Run the publish-outputs command inside the Docker container
+          # Pass:
+          # - build-ref (the git ref, e.g. a tag or branch) for versioning
+          # - code-git-sha (commit hash of the code used for build)
+          # - settings-file-git-sha (commit hash of the saved settings.yaml)
+          # - github-action-run-id (for tracking the GitHub Action run)
+          # - target (indicates if this is 'dev' or 'prod' environment target)
           docker compose run --rm app python dbcp/cli.py publish-outputs \
             -bq \
-            --build-ref ${{ matrix.branch }} \
+            --build-ref ${{ matrix.ref }} \
             --code-git-sha ${{ steps.checkout.outputs.commit }} \
             --settings-file-git-sha $SETTINGS_FILE_SHA \
-            --github-action-run-id ${{ github.run_id }}
+            --github-action-run-id ${{ github.run_id }} \
+            --target ${{ matrix.target }}
 
       - name: Stop Docker Compose services
         if: always()

--- a/README.md
+++ b/README.md
@@ -188,7 +188,44 @@ starts a jupyter lab instance at `http://127.0.0.1:8888/`. If you have another j
 export JUPYTER_PORT=8890
 ```
 
-# Comparing Branches During Development
+# Development Process
+
+## Git Branches
+We have the following branch setup for updating the production and development tables:
+- development schema (`data_warehouse_dev`, `data_mart_dev`): updated using the HEAD of the `main` branch
+- production schema (`data_warehouse`, `data_mart`): updated using the most recent tagged version of the `main` branch
+
+Developing new features or adding new data is done by making a new branch off of `main`, and merging into main allows us to see the results of these changes in the `_dev` schema tables.
+
+### Deploying a new version to production
+We use Git tags to deploy versioned releases to production. The format of these tags is `vYYYY-MM-xx`, where:
+
+- `YYYY` = year
+- `MM` = month
+- `xx` = sequential release number (reset each month)
+
+Only tagged commits are used to update the production schema (`data_warehouse`, `data_mart`). Follow the steps below to create and deploy a new version:
+
+1. Make sure your main branch is up to date:
+```bash
+git checkout main
+git pull origin main
+```
+2. Verify that everything is ready for release
+Ensure that the code in main is what you want deployed to production, and tests have passed.
+
+3. Create a new version tag
+Replace the tag value with the appropriate version:
+```bash
+git tag v2025-08-01  # Example for the first release in August 2025
+```
+4. Push the tag to the remote repository:
+```bash
+git push origin v2025-08-01
+```
+This will trigger the deployment process to update the production schemas with the state of the code at the tagged commit.
+
+## Comparing Branches During Development
 
 In addition to inspecting the data warehouse and data mart tables that are loaded into postgres,
 you may want to compare the data outputs between git branches. The `branch_compare_helper.py`


### PR DESCRIPTION
Changing how the data update process uses information from git branches and tags to decide the update schedule and the target for updating data.

Old:
- Straightforward target schema logic: "dev" branch points to "dev" schema and "main" branch points to "prod" schema (which has no suffix)
- Push to branch triggers update only if dev or main
- Scheduled update for dev and main on same schedule

New:
- Target schema logic: "main" branch head points to "dev" schema, "main" branch with versioned release tag, e.g. "v1.2.3" points to "prod" schema (which has no suffix)
- Push to branch triggers update on main (to dev if head or to prod if versioned tag)
- Scheduled update for main (dev schema) and main with latest versioned tag (latest prod) on same schedule