### PR TITLE
add capacity_mw column to timeseries tables EIA

### DIFF
--- a/docs/data-mart/projects_status_monthly_eia860m.md
+++ b/docs/data-mart/projects_status_monthly_eia860m.md
@@ -13,6 +13,7 @@ This table contains three years of operational status history for each generator
 ||`month_start`|The date of the first day of each month|EIA||
 ||`month_end`|The date of the last day of each month|EIA||
 |Properties|`operational_status_code`|The operational status code defined internally|derived|See the table below for more details|
+||`capacity_mw`|The generator's capacity in megawatts|EIA||
 ||`plant_name_eia`|The name of the plant|EIA||
 
 ## Operational Status Codes

--- a/docs/data-mart/projects_status_quarterly_eia860m.md
+++ b/docs/data-mart/projects_status_quarterly_eia860m.md
@@ -13,6 +13,7 @@ This table contains three years of operational status history for each generator
 ||`quarter_start`|The date of the first day of each quarter|EIA||
 ||`quarter_end`|The date of the last day of each quarter|EIA||
 |Properties|`operational_status_code`|The operational status code defined internally|derived|See the table below for more details|
+||`capacity_mw`|The generator's capacity in megawatts|EIA||
 ||`plant_name_eia`|The name of the plant|EIA||
 
 ## Operational Status Codes

--- a/docs/data-mart/projects_status_yearly_eia860m.md
+++ b/docs/data-mart/projects_status_yearly_eia860m.md
@@ -13,6 +13,7 @@ This table contains three years of operational status history for each generator
 ||`year_start`|The date of the first day of each year|EIA||
 ||`year_end`|The date of the last day of each year|EIA||
 |Properties|`operational_status_code`|The operational status code defined internally|derived|See the table below for more details|
+||`capacity_mw`|The generator's capacity in megawatts|EIA||
 ||`plant_name_eia`|The name of the plant|EIA||
 
 ## Operational Status Codes

--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -697,6 +697,7 @@ projects_status_monthly_eia860m = Table(
     Column("month_start", DateTime, primary_key=True),
     Column("month_end", DateTime, primary_key=True),
     Column("operational_status_code", Integer),
+    Column("capacity_mw", Float),
     schema=schema,
 )
 
@@ -709,6 +710,7 @@ projects_status_quarterly_eia860m = Table(
     Column("quarter_start", DateTime, primary_key=True),
     Column("quarter_end", DateTime, primary_key=True),
     Column("operational_status_code", Integer),
+    Column("capacity_mw", Float),
     schema=schema,
 )
 
@@ -721,6 +723,7 @@ projects_status_yearly_eia860m = Table(
     Column("year_start", DateTime, primary_key=True),
     Column("year_end", DateTime, primary_key=True),
     Column("operational_status_code", Integer),
+    Column("capacity_mw", Float),
     schema=schema,
 )
 


### PR DESCRIPTION
Adding capacity_mw as a column to the data mart timeseries tables for EIA860M.

- Leave capacity_mw column in during the query
- This means dense timeseries cannot be created using stack/unstack (which requires a Pandas Series object) but instead by explicitly creating the date spine and ID spine and creating the grid for which we want to have records, then merging on the data we have
- Add new column to docs and to metadata