### PR TITLE
add latest report date to project status transition dates table

### DIFF
--- a/src/dbcp/data_mart/projects.py
+++ b/src/dbcp/data_mart/projects.py
@@ -998,7 +998,7 @@ def _get_eia860m_transition_dates(engine: sa.engine.Engine) -> pd.DataFrame:
     eia860m_plant_names = _get_plant_names(engine).set_index("plant_id_eia")
     transition_dates = transition_dates.join(eia860m_plant_names, on="plant_id_eia")
 
-    return transition_dates.reset_index(drop=False)
+    return transition_dates
 
 
 def _get_plant_names(

--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -740,6 +740,7 @@ projects_status_transition_dates_eia860m = Table(
     Column("date_entered_7", DateTime),
     Column("date_entered_8", DateTime),
     Column("date_entered_99", DateTime),
+    Column("latest_report_date", DateTime),
     schema=schema,
 )
 

--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -741,6 +741,7 @@ projects_status_transition_dates_eia860m = Table(
     Column("date_entered_8", DateTime),
     Column("date_entered_99", DateTime),
     Column("latest_report_date", DateTime),
+    Column("data_freshness_date", DateTime),
     schema=schema,
 )
 


### PR DESCRIPTION
- Added the latest report date per project / generator in the status transition dates table.
- Also added data freshness date, defined as the most recent report date in the entire table