### PR TITLE
Update data update action workflow to not commit on tagged releases

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -199,11 +199,11 @@ jobs:
       # commit the settings file
       - uses: EndBug/add-and-commit@v9
         id: commit_settings_file
-        if: steps.write_settings.outcome == 'success'
+        if: steps.write_settings.outcome == 'success' && github.ref_type == 'branch'
         with:
           add: "src/dbcp/settings.yaml"
           author_name: "DBCP Bot"
-          author_email: "bennett.norman@catalyst.coop"
+          author_email: "katherine.lamb@catalyst.coop"
           message: "Update settings.yaml"
           push: true
 


### PR DESCRIPTION
When pushing a tagged version release to update the production tables, I encountered an issue in the configuration of the `update-data` workflow. It attempts to update `src.dbcp.settings.yaml` with the generation number for the archived Airtable data. However this tries to commit to a detached head (since the runner is not checking out a branch but rather a commit). We never want to update these generation numbers when running this on a tagged commit because `main` will have already updated with the correct generation numbers and populated the `dev` tables. Update this workflow so that it skips this step when it's not running a branch build.