### PR TITLE
Update readme and workflow yaml to fix tagged releases

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -213,7 +213,7 @@ jobs:
         run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
 
       # Publish the outputs, grab the git SHA of the commit step
-      - name: Publish publish outputs
+      - name: Publish outputs
         run: |
           # Use the commit_settings_file hash if settings.yaml was updated
           # If it wasn't updated, that means there were no changes, so use the

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ We have the following branch setup for updating the production and development t
 Developing new features or adding new data is done by making a new branch off of `main`, and merging into main allows us to see the results of these changes in the `_dev` schema tables.
 
 ### Deploying a new version to production
-We use Git tags to deploy versioned releases to production. The format of these tags is `vYYYY-MM-xx`, where:
+We use Git tags to deploy versioned releases to production. The format of these tags is `vYYYY.MM.DD`, where:
 
 - `YYYY` = year
 - `MM` = month
-- `xx` = sequential release number (reset each month)
+- `DD` = day
 
 Only tagged commits are used to update the production schema (`data_warehouse`, `data_mart`). Follow the steps below to create and deploy a new version:
 
@@ -217,11 +217,11 @@ Ensure that the code in main is what you want deployed to production, and tests 
 3. Create a new version tag
 Replace the tag value with the appropriate version:
 ```bash
-git tag v2025-08-01  # Example for the first release in August 2025
+git tag v2025.08.01  # Example for the first release on August 1, 2025
 ```
 4. Push the tag to the remote repository:
 ```bash
-git push origin v2025-08-01
+git push origin v2025.08.01
 ```
 This will trigger the deployment process to update the production schemas with the state of the code at the tagged commit.
 


### PR DESCRIPTION
Doing the first tagged version push to update the production tables, I fixed a few things in the update-data workflow and in the README. Namely, the version number should use "." instead of "-"