### PR TITLE
Remove null constraint on `plant_name_eia` and `timezone`

### DIFF
--- a/src/dbcp/metadata/data_warehouse.py
+++ b/src/dbcp/metadata/data_warehouse.py
@@ -595,7 +595,7 @@ pudl_generators = Table(
     Column("synchronized_transmission_grid", String),
     Column("technology_description", String),
     Column("time_cold_shutdown_full_load_code", String),
-    Column("timezone", String, nullable=False),
+    Column("timezone", String),
     Column("topping_bottoming_code", String),
     Column("total_fuel_cost", Float),
     Column("total_mmbtu", Float),


### PR DESCRIPTION
The new month of EIA 860M went in last night and this resulted in one of the rows in the `pudl_generators` data warehouse table having a null `plant_name_eia` and `timezone` value. This violated the null constraint on those columns in the `pudl_generators` table, causing the ETL to fail.

Here's the record with the null plant name and timezone (`df` is the `pudl_generators` data warehouse table, which I just created a Parquet of to look at):
<img width="1053" height="115" alt="Screenshot 2025-10-15 at 12 02 11 PM" src="https://github.com/user-attachments/assets/f587cf10-93aa-40bb-9725-c5459f86cdf7" />

Note that this table intentionally only includes data from the latest complete year of EIA 860 data.

When I look at the PUDL `core_eia860m__changelog_generators.parquet` table, I see that at one point this generator was updated with a non-null `plant_name_eia`.
<img width="1054" height="141" alt="Screenshot 2025-10-15 at 12 03 55 PM" src="https://github.com/user-attachments/assets/3ff2fe28-3db4-4e81-a1db-b4b9f75cc33d" />

I also looked at the PUDL `out_eia__yearly_generators.parquet` table and found that there are a handful of records with null `plant_name_eia`, including our generator in question:

<img width="1060" height="242" alt="Screenshot 2025-10-15 at 12 06 18 PM" src="https://github.com/user-attachments/assets/d3158002-f6f7-4f35-aec2-7215e2077808" />

The fix I made here was to allow `plant_name_eia` and `timezone` to be nullable in the `pudl_generators` data warehouse metadata. I felt like this was a valid thing to do because the PUDL metadata allows `plant_name_eia` and `timezone` to be null, and all the other DBCP PUDL data warehouse tables allow `plant_name_eia` to be nullable (`pudl_eia860m_changelog` and `pudl_eia860m_status_codes`).

**There are a few questions I have:**

* Right now the `pudl_generators` table only includes data from the most recent full year of EIA data (2024), but I think that monthly EIA 860M updates can make changes to old records (not just the new month), is that true? Does it make sense that record from 2024 would change? Maybe something in the harvesting process can null out past values if they're not consistent in the provisional 860M data?
* Clearly this record changed from the latest EIA 860M data, why does it not show up in the change log with `valid_until_date = 2025-08-01`?
* Is there a good reason to keep `plant_name_eia` non-nullable?
