### PR TITLE
Add `capacity mw` values to FYI resource capacity table

### DIFF
--- a/notebooks/53-kl-fyi-etl.ipynb
+++ b/notebooks/53-kl-fyi-etl.ipynb
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -307,7 +307,7 @@
        "{nan}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -337,13 +337,57 @@
        " 'capacity_by_generation_type_breakdown']"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "[col for col in raw_df if \"capacity\" in col]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True     35600\n",
+       "False     4107\n",
+       "Name: capacity_by_generation_type_breakdown, dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_df[\"capacity_by_generation_type_breakdown\"].isnull().value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False    38961\n",
+       "True       746\n",
+       "Name: capacity_mw, dtype: int64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_df[\"capacity_mw\"].isnull().value_counts()"
    ]
   },
   {
@@ -460,7 +504,8 @@
     }
    ],
    "source": [
-    "raw_df[~raw_df[\"capacity_by_generation_type_breakdown\"].isnull()][[\"capacity_mw\", \"capacity_by_generation_type_breakdown\"]]"
+    "cap_by_gen_df = raw_df[~raw_df[\"capacity_by_generation_type_breakdown\"].isnull()]\n",
+    "cap_by_gen_df[[\"capacity_mw\", \"capacity_by_generation_type_breakdown\"]]"
    ]
   },
   {
@@ -481,6 +526,173 @@
    ],
    "source": [
     "raw_df[~raw_df[\"capacity_by_generation_type_breakdown\"].isnull()][\"capacity_by_generation_type_breakdown\"].iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test the capacity parsing function in the transform step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dbcp.transform.fyi_queue import parse_capacity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parsed = cap_by_gen_df.apply(parse_capacity, result_type=\"expand\", axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>capacity_by_generation_type_breakdown</th>\n",
+       "      <th>resource</th>\n",
+       "      <th>capacity_mw</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1065</th>\n",
+       "      <td>- canonical_gen_type: Solar\\n  mw: 100\\n- cano...</td>\n",
+       "      <td>[Solar, Battery, Wind]</td>\n",
+       "      <td>[100, 185, 275]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1066</th>\n",
+       "      <td>- canonical_gen_type: Battery\\n  mw: 185\\n- ca...</td>\n",
+       "      <td>[Battery, Solar]</td>\n",
+       "      <td>[185, 375]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1067</th>\n",
+       "      <td>- canonical_gen_type: Battery\\n  mw: 65\\n- can...</td>\n",
+       "      <td>[Battery, Solar]</td>\n",
+       "      <td>[65, 125]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1134</th>\n",
+       "      <td>- canonical_gen_type: Battery\\n  mw: 30\\n- can...</td>\n",
+       "      <td>[Battery, Solar]</td>\n",
+       "      <td>[30, 80]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1341</th>\n",
+       "      <td>- canonical_gen_type: Wind\\n  mw: 50\\n</td>\n",
+       "      <td>[Wind]</td>\n",
+       "      <td>[50]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39238</th>\n",
+       "      <td>- canonical_gen_type: Solar\\n  mw: 200\\n- cano...</td>\n",
+       "      <td>[Solar, Battery]</td>\n",
+       "      <td>[200, 200]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39239</th>\n",
+       "      <td>- canonical_gen_type: Solar\\n  mw: 500\\n- cano...</td>\n",
+       "      <td>[Solar, Battery]</td>\n",
+       "      <td>[500, None]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39244</th>\n",
+       "      <td>- canonical_gen_type: Battery\\n  mw: 200\\n- ca...</td>\n",
+       "      <td>[Battery, Solar]</td>\n",
+       "      <td>[200, 400]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39247</th>\n",
+       "      <td>- canonical_gen_type: Solar\\n  mw: 350\\n- cano...</td>\n",
+       "      <td>[Solar, Battery]</td>\n",
+       "      <td>[350, 350]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39248</th>\n",
+       "      <td>- canonical_gen_type: Solar\\n  mw: 255\\n- cano...</td>\n",
+       "      <td>[Solar, Battery, Solar, Battery]</td>\n",
+       "      <td>[255, 255, 300, 300]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4107 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   capacity_by_generation_type_breakdown  \\\n",
+       "1065   - canonical_gen_type: Solar\\n  mw: 100\\n- cano...   \n",
+       "1066   - canonical_gen_type: Battery\\n  mw: 185\\n- ca...   \n",
+       "1067   - canonical_gen_type: Battery\\n  mw: 65\\n- can...   \n",
+       "1134   - canonical_gen_type: Battery\\n  mw: 30\\n- can...   \n",
+       "1341              - canonical_gen_type: Wind\\n  mw: 50\\n   \n",
+       "...                                                  ...   \n",
+       "39238  - canonical_gen_type: Solar\\n  mw: 200\\n- cano...   \n",
+       "39239  - canonical_gen_type: Solar\\n  mw: 500\\n- cano...   \n",
+       "39244  - canonical_gen_type: Battery\\n  mw: 200\\n- ca...   \n",
+       "39247  - canonical_gen_type: Solar\\n  mw: 350\\n- cano...   \n",
+       "39248  - canonical_gen_type: Solar\\n  mw: 255\\n- cano...   \n",
+       "\n",
+       "                               resource           capacity_mw  \n",
+       "1065             [Solar, Battery, Wind]       [100, 185, 275]  \n",
+       "1066                   [Battery, Solar]            [185, 375]  \n",
+       "1067                   [Battery, Solar]             [65, 125]  \n",
+       "1134                   [Battery, Solar]              [30, 80]  \n",
+       "1341                             [Wind]                  [50]  \n",
+       "...                                 ...                   ...  \n",
+       "39238                  [Solar, Battery]            [200, 200]  \n",
+       "39239                  [Solar, Battery]           [500, None]  \n",
+       "39244                  [Battery, Solar]            [200, 400]  \n",
+       "39247                  [Solar, Battery]            [350, 350]  \n",
+       "39248  [Solar, Battery, Solar, Battery]  [255, 255, 300, 300]  \n",
+       "\n",
+       "[4107 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.concat([cap_by_gen_df[\"capacity_by_generation_type_breakdown\"], parsed], axis=1)"
    ]
   },
   {
@@ -662,6 +874,319 @@
    ],
    "source": [
     "raw_df[raw_df[\"capacity_by_generation_type_breakdown\"]!=\"nan\"][[\"capacity_by_generation_type_breakdown\", \"capacity_mw\", \"canonical_generation_types\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When is capacity reported but not capacity_by_generation_type_breakdown, and vice versa?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cap_no_cap_by_gen_df = raw_df[(~raw_df[\"capacity_mw\"].isnull()) & (raw_df[\"capacity_by_generation_type_breakdown\"].isnull())]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "39707"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(raw_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solar                            12902\n",
+       "Wind                              5821\n",
+       "Battery                           5282\n",
+       "Gas                               3142\n",
+       "Battery + Solar                   3056\n",
+       "Other                             2171\n",
+       "Hydro                              476\n",
+       "Coal                               407\n",
+       "Biomass                            231\n",
+       "Methane                            216\n",
+       "Nuclear                            179\n",
+       "Geothermal                         120\n",
+       "Gas + Oil                          114\n",
+       "Diesel                             109\n",
+       "Offshore Wind                       88\n",
+       "Battery + Wind                      87\n",
+       "Oil                                 79\n",
+       "Pumped Storage                      75\n",
+       "Battery + Solar + Wind              50\n",
+       "Biogas                              46\n",
+       "Landfill                            36\n",
+       "Waste Heat                          34\n",
+       "Solar + Wind                        24\n",
+       "Battery + Gas + Solar               18\n",
+       "Battery + Gas                       15\n",
+       "Fuel Cell                            9\n",
+       "Compressed Air                       8\n",
+       "Gas + Solar                          7\n",
+       "Biofuel                              7\n",
+       "Battery + Hydro                      7\n",
+       "Hydrogen                             4\n",
+       "Flywheel                             4\n",
+       "Coal + Gas                           3\n",
+       "Coal + Oil                           2\n",
+       "Other Storage                        2\n",
+       "Waste                                2\n",
+       "Gas + Wind                           2\n",
+       "Diesel + Methane                     2\n",
+       "Pumped Storage + Solar + Wind        2\n",
+       "Biomass + Oil                        2\n",
+       "Diesel + Solar                       1\n",
+       "Battery + Diesel + Gas               1\n",
+       "Methane + Solar                      1\n",
+       "Biomass + Solar                      1\n",
+       "Biomass + Coal                       1\n",
+       "Geothermal + Solar                   1\n",
+       "Battery + Oil                        1\n",
+       "Hydro + Solar                        1\n",
+       "Battery + Compressed Air             1\n",
+       "Compressed Air + Gas                 1\n",
+       "Geothermal + Waste Heat              1\n",
+       "Biomass + Gas                        1\n",
+       "Diesel + Gas                         1\n",
+       "Name: canonical_generation_types, dtype: int64"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cap_no_cap_by_gen_df.canonical_generation_types.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0        Pumped Storage\n",
+       "1                 Solar\n",
+       "2                  Wind\n",
+       "3                 Solar\n",
+       "4                 Solar\n",
+       "              ...      \n",
+       "39695             Solar\n",
+       "39696             Solar\n",
+       "39697             Solar\n",
+       "39698             Solar\n",
+       "39699             Solar\n",
+       "Name: canonical_generation_types, Length: 34854, dtype: object"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cap_no_cap_by_gen_df.canonical_generation_types.str.replace(r'^Battery\\s\\+\\s|\\s\\+\\sBattery', \"\", regex=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res_cap_df = pd.read_parquet(\"/app/data/output/private_data_warehouse/fyi_resource_capacity.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>project_id</th>\n",
+       "      <th>resource</th>\n",
+       "      <th>resource_clean</th>\n",
+       "      <th>capacity_mw</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>avista-110</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>avista-110</td>\n",
+       "      <td>Battery</td>\n",
+       "      <td>Battery Storage</td>\n",
+       "      <td>185.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>avista-110</td>\n",
+       "      <td>Wind</td>\n",
+       "      <td>Onshore Wind</td>\n",
+       "      <td>275.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>avista-111</td>\n",
+       "      <td>Battery</td>\n",
+       "      <td>Battery Storage</td>\n",
+       "      <td>185.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>avista-111</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>375.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36230</th>\n",
+       "      <td>wapa-rocky-mountain-region-2024-g3</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>170.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36231</th>\n",
+       "      <td>wapa-rocky-mountain-region-2024-g4</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>170.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36232</th>\n",
+       "      <td>wapa-rocky-mountain-region-2025-g1</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>250.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36233</th>\n",
+       "      <td>wapa-rocky-mountain-region-2025-g2</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>Solar</td>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36234</th>\n",
+       "      <td>wapa-rocky-mountain-region-2025-g4</td>\n",
+       "      <td>Wind</td>\n",
+       "      <td>Onshore Wind</td>\n",
+       "      <td>500.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>36235 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               project_id resource   resource_clean  \\\n",
+       "0                              avista-110    Solar            Solar   \n",
+       "1                              avista-110  Battery  Battery Storage   \n",
+       "2                              avista-110     Wind     Onshore Wind   \n",
+       "3                              avista-111  Battery  Battery Storage   \n",
+       "4                              avista-111    Solar            Solar   \n",
+       "...                                   ...      ...              ...   \n",
+       "36230  wapa-rocky-mountain-region-2024-g3    Solar            Solar   \n",
+       "36231  wapa-rocky-mountain-region-2024-g4    Solar            Solar   \n",
+       "36232  wapa-rocky-mountain-region-2025-g1    Solar            Solar   \n",
+       "36233  wapa-rocky-mountain-region-2025-g2    Solar            Solar   \n",
+       "36234  wapa-rocky-mountain-region-2025-g4     Wind     Onshore Wind   \n",
+       "\n",
+       "       capacity_mw  \n",
+       "0            100.0  \n",
+       "1            185.0  \n",
+       "2            275.0  \n",
+       "3            185.0  \n",
+       "4            375.0  \n",
+       "...            ...  \n",
+       "36230        170.0  \n",
+       "36231        170.0  \n",
+       "36232        250.0  \n",
+       "36233        200.0  \n",
+       "36234        500.0  \n",
+       "\n",
+       "[36235 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res_cap_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ids to look into\n",
+    "# caiso-1085, caiso-1088, caiso-472, caiso-54873, caiso-908, caiso-955, tucson-electric-power-94 (solar and battery)"
    ]
   },
   {


### PR DESCRIPTION
We previously were creating the FYI resource capacity table just from the `capacity_by_generation_type_breakdown` column. However the `capacity_mw` column is much more rich and we didn't use it in the original data warehouse creation. Get the values from this column and concatenate them with the values we're already grabbing.

Most of the projects which don't have a capacity_by_generation_type_breakdown listed only have a single resource, but some have multiple resources listed for only one capacity value, which is problematic. To try to fix some of these, I assumed that any "Battery + x" resource type has a capacity value that pertains to the non-battery resource only. I then dropped any rows that still have a mixed resource type (i.e. "Wind + Solar") because I wasn't sure what to attribute the capacity to. Follow up item to ask FYI about this.

- [x] Make a follow up issue to look into the dropped multi resource values
- [x] Make a follow up issue to investigate the 8 project IDs that have conflicting capacity_mw and capacity_by_generation_type_breakdown values for the same resource type

See #478 