### PR TITLE
Fix update_data branch runs

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -262,16 +262,6 @@ jobs:
             SETTINGS_FILE_SHA="${{ steps.checkout.outputs.commit }}"
           fi
 
-          CODE_SHA="${{ steps.checkout.outputs.commit }}"
-
-          # Conform to publish-outputs validation:
-          # dev -> build-ref=main; prod -> build-ref=v* tag
-          if [[ "${{ matrix.target }}" == "dev" ]]; then
-            BUILD_REF="main"
-          else
-            BUILD_REF="${{ matrix.ref }}"   # should be the release tag (v*)
-          fi
-
           # Run the publish-outputs command inside the Docker container
           # Pass:
           # - build-ref (the git ref, e.g. a tag or branch) for versioning
@@ -281,8 +271,8 @@ jobs:
           # - target (indicates if this is 'dev' or 'prod' environment target)
           docker compose run --rm app python dbcp/cli.py publish-outputs \
             -bq \
-            --build-ref "$BUILD_REF" \
-            --code-git-sha "$CODE_SHA" \
+            --build-ref ${{ matrix.ref }} \
+            --code-git-sha ${{ steps.checkout.outputs.commit }} \
             --settings-file-git-sha $SETTINGS_FILE_SHA \
             --github-action-run-id ${{ github.run_id }} \
             --target ${{ matrix.target }}

--- a/src/dbcp/commands/publish.py
+++ b/src/dbcp/commands/publish.py
@@ -140,14 +140,21 @@ class OutputMetadata(BaseModel):
 
     @validator("git_ref")
     def git_ref_must_be_main_or_tag(cls, git_ref: str | None) -> str | None:
-        """Validate that the git ref is either "main" or "vX.Y.Z"."""
-        if git_ref:
-            if git_ref in ("main",) or re.fullmatch(r"^v\d+\.\d+\.\d+$", git_ref):
-                return git_ref
-            raise ValueError(
-                f'{git_ref} is not a valid Git ref. Must be "main" or a git tag starting with "v".'
-            )
-        return git_ref
+        """Validate that the git ref is 'main', a tag like vX.Y.Z, or a valid branch name."""
+        if not git_ref:
+            return git_ref
+
+        # main or semantic version tag
+        if git_ref == "main" or re.fullmatch(r"^v\d+\.\d+\.\d+$", git_ref):
+            return git_ref
+
+        # allow typical branch names: feature/foo, fix-bar, dev, etc.
+        if re.fullmatch(r"^(?!/)(?!.*//)[A-Za-z0-9._\-/]+(?<!/)$", git_ref):
+            return git_ref
+
+        raise ValueError(
+            f"{git_ref} is not a valid Git ref. Must be 'main', a git tag starting with 'v', or a valid branch name."
+        )
 
     @validator("target")
     def target_must_be_dev_or_prod(cls, target: str | None) -> str | None:


### PR DESCRIPTION
This PR fixes the `update-data` workflow when running it from a workflow dispatch trigger on a feature branch. I tried to this from my FYI data mart branch and it failed publishing the outputs (see [here](https://github.com/deployment-gap-model-education-fund/deployment-gap-model/actions/runs/19114473069/job/54620044138#step:16:64)).

I'm not sure at what point this broke, but it seems like the issue in that failing run is that there's a validator that enforces that the git ref must be main or tag at that step. I updated that function to allow for a generic branch name. 

Alternatively, I think I could update the [Publish Outputs step of the `update-data.yml` file](https://github.com/deployment-gap-model-education-fund/deployment-gap-model/blob/main/.github/workflows/update-data.yml#L274) so that --build-ref is always `main` even when running off a commit from a different branch, and the --code-git-sha commit would point to the branch commit that you're running the workflow from. Does that make any sense? 

I thought changing the validator seemed easier.