### PR TITLE
Fix `dependabot.yml` by removing target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "dev"
     labels:
       - "dependencies"
     schedule:
@@ -10,6 +9,5 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "dev"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I think this fixes failing dependabot runs (logs [here](https://github.com/deployment-gap-model-education-fund/deployment-gap-model/actions/runs/19417002101/job/55547131373))

Dependabot previously ran dependency updates against the `dev` branch, but we no longer have a `dev` branch and instead just update `dev` and `prod` tables from the `main` branch. I updated the `.github/dependabot.yml` file to not specify a target branch, so that it will by default use the default branch (`main`).