### PR TITLE
Remove docker-compose

### DIFF
--- a/.github/workflows/test-full-build.yml
+++ b/.github/workflows/test-full-build.yml
@@ -41,14 +41,9 @@ jobs:
       - name: Give the dbcp user ownership of the workspace
         run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
 
-      - name: Set up Docker Compose
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
-
       - name: Build and run Docker Compose services
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: Run full ETL
         run: |
@@ -61,7 +56,7 @@ jobs:
       - name: Stop Docker Compose services
         if: always()
         run: |
-          docker-compose down
+          docker compose down
 
       # The google-github-actions/auth step is run as runner:docker,
       # so we need to give the workspace back to runner:docker

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -54,14 +54,9 @@ jobs:
       - name: Give the dbcp user ownership of the workspace
         run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
 
-      - name: Set up Docker Compose
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
-
       - name: Build and run Docker Compose services
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: Run the archive
         env:
@@ -208,14 +203,9 @@ jobs:
       - name: Give the dbcp user ownership of the workspace
         run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
 
-      - name: Set up Docker Compose
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
-
       - name: Build and run Docker Compose services
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: Run full ETL
         if: ${{ success() }}
@@ -284,7 +274,7 @@ jobs:
       - name: Stop Docker Compose services
         if: always()
         run: |
-          docker-compose down
+          docker compose down
 
       # The google-github-actions/auth step is run as runner:docker,
       # so we need to give the workspace back to runner:docker


### PR DESCRIPTION
When using `ubuntu-latest` for GH runners it's unnecessary to install docker-compose. This removes the docker-compose step entirely and switches to using `docker compose` in the GH workflows for `update-data` and `test-full-build`