### PR TITLE
ETL FYI November data update

### DIFF
--- a/notebooks/data_updates/interconnection_fyi/interconnection-fyi-update.ipynb
+++ b/notebooks/data_updates/interconnection_fyi/interconnection-fyi-update.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "old_fyi = dbcp.extract.fyi_queue.extract(\"gs://dgm-archive/interconnection.fyi/interconnection_fyi_dataset_2025-10-01.csv\")\n",
+    "old_fyi = dbcp.extract.fyi_queue.extract(\"gs://dgm-archive/interconnection.fyi/interconnection_fyi_dataset_2025-11-04.csv\")\n",
     "old_fyi = old_fyi[\"fyi_queue\"]"
    ]
   },
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_fyi = dbcp.extract.fyi_queue.extract(\"gs://dgm-archive/interconnection.fyi/interconnection_fyi_dataset_2025-11-04.csv\")\n",
+    "new_fyi = dbcp.extract.fyi_queue.extract(\"gs://dgm-archive/interconnection.fyi/interconnection_fyi_dataset_2025-12-01.csv\")\n",
     "new_fyi = new_fyi[\"fyi_queue\"]"
    ]
   },
@@ -100,6 +100,16 @@
     "    print(f\" - Old max date {old_df['queue_date'].max()}\")\n",
     "    print(f\" - New max date {new_df['queue_date'].max()}\")\n",
     "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fe30ec8-e58e-4dc7-8189-8cdb3947bc1f",
+   "metadata": {},
+   "source": [
+    "# Create data warehouse and data mart tables\n",
+    "\n",
+    "Update the URI of the archived FYI data in `dbcp.etl.etl_fyi_queue`. Then run `make all` to generate the data warehouse and data mart tables. Debug any errors that arise."
    ]
   },
   {
@@ -239,7 +249,7 @@
     "\n",
     "table_name = \"fyi_projects_long_format\"\n",
     "version = get_bigquery_table_version(\"private_data_mart_dev\", table_name)\n",
-    "uri = f\"gs://dgm-outputs/{version}/data_mart/{table_name}.parquet\"\n",
+    "uri = f\"gs://dgm-outputs/{version}/private_data_mart/{table_name}.parquet\"\n",
     "data_cache = \"/app/data/gcp_outputs\"\n",
     "\n",
     "fyi_projects_long_format_path = cache_gcs_archive_file_locally(uri, data_cache)\n",
@@ -324,7 +334,7 @@
    "id": "c1a171a1-e66e-4190-8e39-442348a0d323",
    "metadata": {},
    "source": [
-    "Make sure there isn't an surprising change in total capacity between the old and new data. We currently don't expect the active capacity to change that much in the span of a quarter. The `max_change` value is an arbitrary number so dig into the data if something looks fishy to you.\n",
+    "Make sure there isn't an surprising change in total capacity between the old and new data. We currently don't expect the active capacity to change that much in the span of a month. The `max_change` value is an arbitrary number so dig into the data if something looks fishy to you.\n",
     "\n",
     "It's challenging to validate total capacity changes in ISOs. If there is an unexpected change, I would check the ISO's website to see if they changed their study process. For example, there was a surprising drop in active capacity in NYISO during the 2024 Q4 update. It turns out they [changed their study process](https://www.utilitydive.com/news/new-york-iso-reforms-interconnection-queue-launches-cluster-study/724054/) and the layout of the spreadsheet Gridstatus pulls in. Sites like S&P and Utility Drive might have relevant informaiton."
    ]

--- a/src/dbcp/constants.py
+++ b/src/dbcp/constants.py
@@ -208,6 +208,7 @@ FYI_RESOURCE_DICT = {
             "Gas + Wind",
             "Compressed Air + Gas",
             "Methane",
+            "Battery + Fuel Cell + Gas",
         ],
         "type": "Fossil",
     },

--- a/src/dbcp/etl.py
+++ b/src/dbcp/etl.py
@@ -44,7 +44,7 @@ def etl_lbnl_iso_queue() -> Dict[str, pd.DataFrame]:
 
 def etl_fyi_queue() -> Dict[str, pd.DataFrame]:
     """Interconnection.fyi ISO Queues ETL."""
-    fyi_uri = "gs://dgm-archive/interconnection.fyi/interconnection_fyi_dataset_2025-11-04.csv"
+    fyi_uri = "gs://dgm-archive/interconnection.fyi/interconnection_fyi_dataset_2025-12-01.csv"
     fyi_raw_dfs = dbcp.extract.fyi_queue.extract(fyi_uri)
     fyi_transformed_dfs = dbcp.transform.fyi_queue.transform(fyi_raw_dfs)
     return fyi_transformed_dfs


### PR DESCRIPTION
This PR runs the November interconnection.fyi data update. No major changes were found from running the data update notebook. There was less than 10% change in capacity in every ISO. I added a resource for "Battery + Fuel Cell + Gas" that maps to "Natural Gas" as its clean resource. This kept with the convention we've been using for other multi resources.