### PR TITLE
Spot fix geocoder issues

### DIFF
--- a/src/dbcp/transform/eip_infrastructure.py
+++ b/src/dbcp/transform/eip_infrastructure.py
@@ -207,6 +207,9 @@ def facilities_transform(raw_fac_df: pd.DataFrame) -> pd.DataFrame:
     fac = add_county_fips_with_backup_geocoding(
         fac, state_col="state", locality_col="county"
     )
+    # TODO: this is a temporary spot fix for mysterious geocoder changes
+    # make sure this is correctly geocoded when we switch to the official
+    # Python client library
     fac.loc[
         fac.county_id_fips != fac.county_fips_code, "geocoded_containing_county"
     ] = "DeSoto Parish"

--- a/src/dbcp/transform/local_opposition.py
+++ b/src/dbcp/transform/local_opposition.py
@@ -94,6 +94,8 @@ def _transform_local_ordinances(local_ord_df: pd.DataFrame) -> pd.DataFrame:
     for col in string_cols:
         local.loc[:, col] = local.loc[:, col].str.strip()
 
+    # TODO: check if Saratoga County still needs a correction
+    # when geocodio-library-python goes in
     # manual corrections
     location_corrections = {
         "Batavia Township (Clermont County)": "Branch County",

--- a/test/unit/test_geocoding.py
+++ b/test/unit/test_geocoding.py
@@ -369,6 +369,8 @@ def test_add_county_fips_with_backup_geocoding_empty_df():
                 "geocoded_containing_county": "Sonoma County",
             },
         ),
+        # TODO: fix this / catch unknown location when official
+        # python client library is integrated
         pytest.param(
             {"state": "XX", "county": "Random locality name"},
             {


### PR DESCRIPTION
Mysterious changes in how `pygeocodio` geocodes a few values were causing the ETL to fail. This PR adds some spot fixes to make the ETL pass, but ultimately we probably need to fix this by switching to the official `geocodio` Python client library (see #506 )