### PR TITLE
Add planned repower date to EIA 860M change log table

### DIFF
--- a/src/dbcp/metadata/data_warehouse.py
+++ b/src/dbcp/metadata/data_warehouse.py
@@ -655,6 +655,7 @@ pudl_eia860m_changelog = Table(
     Column("planned_generator_retirement_date", DateTime),
     Column("planned_net_summer_capacity_derate_mw", Float),
     Column("planned_net_summer_capacity_uprate_mw", Float),
+    Column("planned_repower_date", DateTime),
     Column("planned_uprate_date", DateTime),
     Column("prime_mover_code", String),
     Column("sector_id_eia", Integer),


### PR DESCRIPTION
The October update of EIA 860M introduced a new column to the EIA 860M change log table called `planned_repower_date`. This column has appeared in 860M before, but hasn't shown up in the changelog until now. Add this column to the metadata for the change log table.