### PR TITLE
Temporarily disable postgres upload of prod tables

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -261,6 +261,7 @@ jobs:
 
           # Run the publish-outputs command inside the Docker container
           # Pass:
+          # - upload-to-postgres to upload tables to production postgres, disabled temporarily
           # - build-ref (the git ref, e.g. a tag or branch) for versioning
           # - code-git-sha (commit hash of the code used for build)
           # - settings-file-git-sha (commit hash of the saved settings.yaml)
@@ -268,7 +269,6 @@ jobs:
           # - target (indicates if this is 'dev' or 'prod' environment target)
           docker compose run --rm app python dbcp/cli.py publish-outputs \
             -bq \
-            --upload-to-postgres \
             --build-ref ${{ matrix.ref }} \
             --code-git-sha ${{ steps.checkout.outputs.commit }} \
             --settings-file-git-sha $SETTINGS_FILE_SHA \


### PR DESCRIPTION
The migration of tables to Postgres via the `update-data` Github action doesn't work right now because GitHub Actions runs on IPv4 protocol, whereas Supabase runs on IPv6. The fix for this is enabling `ipv4` on Supabase. But for now, temporarily disable this migration of tables.